### PR TITLE
release: prepare v1.1.20 build 19

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.19+18
+version: 1.1.20+19
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
Prepare the next app release after the native Apple OAuth flow merge. Updates the store version to 1.1.20 and build number 19.