### PR TITLE
fix(settings): preserve default runtime fields

### DIFF
--- a/lib/contracts/proto_mapping.dart
+++ b/lib/contracts/proto_mapping.dart
@@ -711,71 +711,167 @@ Map<String, dynamic> runtimeSettingsSectionToJson(
   return switch (section) {
     'server' =>
       settings.hasServer()
-          ? protoMessageToJsonMap(settings.server)
+          ? _runtimeSettingsWithDefaults(settings.server, {
+              'name': settings.server.name,
+            })
           : <String, dynamic>{},
     'roomDefaults' =>
       settings.hasRoomDefaults()
-          ? protoMessageToJsonMap(settings.roomDefaults)
+          ? _runtimeSettingsWithDefaults(settings.roomDefaults, {
+              'defaultMaxMembers': settings.roomDefaults.defaultMaxMembers
+                  .toString(),
+              'defaultMaxChatMessages': settings
+                  .roomDefaults
+                  .defaultMaxChatMessages
+                  .toString(),
+            })
           : <String, dynamic>{},
     'permissions' =>
       settings.hasPermissions()
-          ? protoMessageToJsonMap(settings.permissions)
+          ? _runtimeSettingsWithDefaults(settings.permissions, {
+              'adminDefaultPermissions': settings
+                  .permissions
+                  .adminDefaultPermissions
+                  .toString(),
+              'memberDefaultPermissions': settings
+                  .permissions
+                  .memberDefaultPermissions
+                  .toString(),
+              'guestDefaultPermissions': settings
+                  .permissions
+                  .guestDefaultPermissions
+                  .toString(),
+            })
           : <String, dynamic>{},
     'roomCreation' =>
       settings.hasRoomCreation()
-          ? protoMessageToJsonMap(settings.roomCreation)
+          ? _runtimeSettingsWithDefaults(settings.roomCreation, {
+              'enabled': settings.roomCreation.enabled,
+              'approvalRequired': settings.roomCreation.approvalRequired,
+              'maxRoomsPerUser': settings.roomCreation.maxRoomsPerUser
+                  .toString(),
+            })
           : <String, dynamic>{},
     'user' =>
       settings.hasUser()
-          ? protoMessageToJsonMap(settings.user)
+          ? _runtimeSettingsWithDefaults(settings.user, {
+              'enablePasswordSignup': settings.user.enablePasswordSignup,
+              'passwordSignupNeedReview':
+                  settings.user.passwordSignupNeedReview,
+              'enableEmailSignup': settings.user.enableEmailSignup,
+              'emailSignupNeedReview': settings.user.emailSignupNeedReview,
+              'enableWebauthnSignup': settings.user.enableWebauthnSignup,
+              'webauthnSignupNeedReview':
+                  settings.user.webauthnSignupNeedReview,
+              'enableGuest': settings.user.enableGuest,
+            })
           : <String, dynamic>{},
     'oauth2' =>
       settings.hasOauth2()
-          ? protoMessageToJsonMap(settings.oauth2)
+          ? _oauth2RuntimeSettingsToJson(settings.oauth2)
           : <String, dynamic>{},
     'rtmp' => _rtmpRuntimeSettingsToJson(settings),
     'email' => _emailRuntimeSettingsToJson(settings),
     'webrtc' =>
       settings.hasWebrtc()
-          ? protoMessageToJsonMap(settings.webrtc)
+          ? _runtimeSettingsWithDefaults(settings.webrtc, {
+              'externalIceServers': [
+                for (final server in settings.webrtc.externalIceServers)
+                  protoMessageToJsonMap(server),
+              ],
+              'maxVoiceParticipantsPerRoom':
+                  settings.webrtc.maxVoiceParticipantsPerRoom,
+            })
           : <String, dynamic>{},
     'chat' =>
       settings.hasChat()
-          ? protoMessageToJsonMap(settings.chat)
+          ? _runtimeSettingsWithDefaults(settings.chat, {
+              'maxMessagesPerRoom': settings.chat.maxMessagesPerRoom.toString(),
+              'maxPinnedMessagesPerRoom': settings.chat.maxPinnedMessagesPerRoom
+                  .toString(),
+              'messageRetentionDays': settings.chat.messageRetentionDays
+                  .toString(),
+            })
           : <String, dynamic>{},
     'playbackHistory' =>
       settings.hasPlaybackHistory()
-          ? protoMessageToJsonMap(settings.playbackHistory)
+          ? _runtimeSettingsWithDefaults(settings.playbackHistory, {
+              'retentionDays': settings.playbackHistory.retentionDays,
+              'maxEntriesPerRoom': settings.playbackHistory.maxEntriesPerRoom
+                  .toString(),
+            })
           : <String, dynamic>{},
     'cors' =>
       settings.hasCors()
-          ? protoMessageToJsonMap(settings.cors)
+          ? _runtimeSettingsWithDefaults(settings.cors, {
+              'allowedOrigins': List<String>.from(settings.cors.allowedOrigins),
+            })
           : <String, dynamic>{},
     _ => <String, dynamic>{},
   };
 }
 
+Map<String, dynamic> _runtimeSettingsWithDefaults(
+  pb.GeneratedMessage message,
+  Map<String, dynamic> defaults,
+) {
+  final json = protoMessageToJsonMap(message);
+  for (final entry in defaults.entries) {
+    json.putIfAbsent(entry.key, () => entry.value);
+  }
+  return json;
+}
+
+Map<String, dynamic> _oauth2RuntimeSettingsToJson(
+  admin.OAuth2Settings settings,
+) {
+  final json = _runtimeSettingsWithDefaults(settings, {
+    'allowedRedirectUrls': List<String>.from(settings.allowedRedirectUrls),
+  });
+  json['providers'] = [
+    for (final provider in settings.providers)
+      _runtimeSettingsWithDefaults(provider, {
+        'enableSignup': provider.enableSignup,
+        'signupNeedReview': provider.signupNeedReview,
+      }),
+  ];
+  return json;
+}
+
 Map<String, dynamic> _rtmpRuntimeSettingsToJson(
   admin.RuntimeSettings settings,
 ) {
-  final json = settings.hasRtmp()
-      ? protoMessageToJsonMap(settings.rtmp)
-      : <String, dynamic>{};
-  json.putIfAbsent('customPublishHost', () => null);
-  return json;
+  if (!settings.hasRtmp()) return <String, dynamic>{};
+  return _runtimeSettingsWithDefaults(settings.rtmp, {
+    'customPublishHost': settings.rtmp.hasCustomPublishHost()
+        ? settings.rtmp.customPublishHost
+        : null,
+    'tsDisguisedAsPng': settings.rtmp.tsDisguisedAsPng,
+  });
 }
 
 Map<String, dynamic> _emailRuntimeSettingsToJson(
   admin.RuntimeSettings settings,
 ) {
-  final json = settings.hasEmail()
-      ? protoMessageToJsonMap(settings.email)
-      : <String, dynamic>{};
-  json.putIfAbsent('smtpHost', () => null);
-  json.putIfAbsent('smtpCredentials', () => null);
-  json.putIfAbsent('smtpProxy', () => null);
-  json.putIfAbsent('fromEmail', () => null);
-  return json;
+  if (!settings.hasEmail()) return <String, dynamic>{};
+  return _runtimeSettingsWithDefaults(settings.email, {
+    'enabled': settings.email.enabled,
+    'smtpHost': settings.email.hasSmtpHost() ? settings.email.smtpHost : null,
+    'smtpPort': settings.email.smtpPort,
+    'smtpCredentials': settings.email.hasSmtpCredentials()
+        ? protoMessageToJsonMap(settings.email.smtpCredentials)
+        : null,
+    'smtpProxy': settings.email.hasSmtpProxy()
+        ? protoMessageToJsonMap(settings.email.smtpProxy)
+        : null,
+    'useTls': settings.email.useTls,
+    'fromEmail': settings.email.hasFromEmail()
+        ? settings.email.fromEmail
+        : null,
+    'fromName': settings.email.fromName,
+    'whitelistEnabled': settings.email.whitelistEnabled,
+    'whitelistDomains': List<String>.from(settings.email.whitelistDomains),
+  });
 }
 
 String oauth2ProviderTypeToString(oauth2_enum.OAuth2ProviderType provider) {

--- a/lib/contracts/proto_mapping.dart
+++ b/lib/contracts/proto_mapping.dart
@@ -841,37 +841,39 @@ Map<String, dynamic> _oauth2RuntimeSettingsToJson(
 Map<String, dynamic> _rtmpRuntimeSettingsToJson(
   admin.RuntimeSettings settings,
 ) {
-  if (!settings.hasRtmp()) return <String, dynamic>{};
-  return _runtimeSettingsWithDefaults(settings.rtmp, {
-    'customPublishHost': settings.rtmp.hasCustomPublishHost()
-        ? settings.rtmp.customPublishHost
+  final rtmp = settings.hasRtmp() ? settings.rtmp : admin.RtmpSettings();
+  final defaults = <String, dynamic>{
+    'customPublishHost': rtmp.hasCustomPublishHost()
+        ? rtmp.customPublishHost
         : null,
-    'tsDisguisedAsPng': settings.rtmp.tsDisguisedAsPng,
-  });
+    'tsDisguisedAsPng': rtmp.tsDisguisedAsPng,
+  };
+  if (!settings.hasRtmp()) return defaults;
+  return _runtimeSettingsWithDefaults(rtmp, defaults);
 }
 
 Map<String, dynamic> _emailRuntimeSettingsToJson(
   admin.RuntimeSettings settings,
 ) {
-  if (!settings.hasEmail()) return <String, dynamic>{};
-  return _runtimeSettingsWithDefaults(settings.email, {
-    'enabled': settings.email.enabled,
-    'smtpHost': settings.email.hasSmtpHost() ? settings.email.smtpHost : null,
-    'smtpPort': settings.email.smtpPort,
-    'smtpCredentials': settings.email.hasSmtpCredentials()
-        ? protoMessageToJsonMap(settings.email.smtpCredentials)
+  final email = settings.hasEmail() ? settings.email : admin.EmailSettings();
+  final defaults = <String, dynamic>{
+    'enabled': email.enabled,
+    'smtpHost': email.hasSmtpHost() ? email.smtpHost : null,
+    'smtpPort': email.smtpPort,
+    'smtpCredentials': email.hasSmtpCredentials()
+        ? protoMessageToJsonMap(email.smtpCredentials)
         : null,
-    'smtpProxy': settings.email.hasSmtpProxy()
-        ? protoMessageToJsonMap(settings.email.smtpProxy)
+    'smtpProxy': email.hasSmtpProxy()
+        ? protoMessageToJsonMap(email.smtpProxy)
         : null,
-    'useTls': settings.email.useTls,
-    'fromEmail': settings.email.hasFromEmail()
-        ? settings.email.fromEmail
-        : null,
-    'fromName': settings.email.fromName,
-    'whitelistEnabled': settings.email.whitelistEnabled,
-    'whitelistDomains': List<String>.from(settings.email.whitelistDomains),
-  });
+    'useTls': email.useTls,
+    'fromEmail': email.hasFromEmail() ? email.fromEmail : null,
+    'fromName': email.fromName,
+    'whitelistEnabled': email.whitelistEnabled,
+    'whitelistDomains': List<String>.from(email.whitelistDomains),
+  };
+  if (!settings.hasEmail()) return defaults;
+  return _runtimeSettingsWithDefaults(email, defaults);
 }
 
 String oauth2ProviderTypeToString(oauth2_enum.OAuth2ProviderType provider) {

--- a/test/contracts/proto_mapping_test.dart
+++ b/test/contracts/proto_mapping_test.dart
@@ -103,4 +103,32 @@ void main() {
     expect((providers as List).single, containsPair('enableSignup', false));
     expect(providers.single, containsPair('signupNeedReview', false));
   });
+
+  test('keeps editable settings when optional sections are absent', () {
+    final settings = admin.RuntimeSettings();
+
+    expect(
+      runtimeSettingsSectionToJson(settings, 'rtmp'),
+      containsPair('customPublishHost', isNull),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'rtmp'),
+      containsPair('tsDisguisedAsPng', false),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'email').keys,
+      containsAll(<String>[
+        'enabled',
+        'smtpHost',
+        'smtpPort',
+        'smtpCredentials',
+        'smtpProxy',
+        'useTls',
+        'fromEmail',
+        'fromName',
+        'whitelistEnabled',
+        'whitelistDomains',
+      ]),
+    );
+  });
 }

--- a/test/contracts/proto_mapping_test.dart
+++ b/test/contracts/proto_mapping_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:synctv_app/contracts/proto_mapping.dart';
+import 'package:synctv_app/src/generated/proto/admin.pb.dart' as admin;
 import 'package:synctv_app/src/generated/proto/oauth2.pbenum.dart';
 
 void main() {
@@ -37,5 +38,69 @@ void main() {
         isEmpty,
       );
     });
+  });
+
+  test('keeps proto3 default-valued runtime settings in section maps', () {
+    final settings = admin.RuntimeSettings(
+      user: admin.UserSettings()..mergeFromProto3Json(<String, dynamic>{}),
+      roomCreation: admin.RoomCreationSettings()
+        ..mergeFromProto3Json(<String, dynamic>{}),
+      email: admin.EmailSettings()..mergeFromProto3Json(<String, dynamic>{}),
+      rtmp: admin.RtmpSettings()..mergeFromProto3Json(<String, dynamic>{}),
+    );
+
+    expect(
+      runtimeSettingsSectionToJson(settings, 'user').keys,
+      containsAll(<String>[
+        'enablePasswordSignup',
+        'passwordSignupNeedReview',
+        'enableEmailSignup',
+        'emailSignupNeedReview',
+        'enableWebauthnSignup',
+        'webauthnSignupNeedReview',
+        'enableGuest',
+      ]),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'user')['enableGuest'],
+      isFalse,
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'roomCreation').keys,
+      containsAll(<String>['enabled', 'approvalRequired']),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'email').keys,
+      containsAll(<String>[
+        'enabled',
+        'smtpPort',
+        'useTls',
+        'fromName',
+        'whitelistEnabled',
+        'whitelistDomains',
+      ]),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'rtmp').keys,
+      contains('tsDisguisedAsPng'),
+    );
+
+    final oauth2Settings = admin.OAuth2Settings()
+      ..mergeFromProto3Json({
+        'providers': [
+          {
+            'name': 'github',
+            'github': {'clientId': 'id'},
+          },
+        ],
+      });
+    final oauth2 = admin.RuntimeSettings(oauth2: oauth2Settings);
+    final providers = runtimeSettingsSectionToJson(
+      oauth2,
+      'oauth2',
+    )['providers'];
+    expect(providers, isA<List<dynamic>>());
+    expect((providers as List).single, containsPair('enableSignup', false));
+    expect(providers.single, containsPair('signupNeedReview', false));
   });
 }


### PR DESCRIPTION
## Changes
- include proto3 default-valued runtime settings in section maps
- preserve nested OAuth2 provider defaults
- add regression coverage for default-valued settings serialization

## Verification
- flutter analyze
- flutter test test/contracts/proto_mapping_test.dart