### PR TITLE
fix(auth): retain desktop OAuth callback listeners

### DIFF
--- a/docs/oauth2-callbacks.md
+++ b/docs/oauth2-callbacks.md
@@ -1,9 +1,10 @@
 # OAuth2 callback configuration
 
-Android, Windows, and Linux run OAuth2 sessions through `flutter_web_auth_2`.
-iOS and macOS use a small app-owned bridge to AuthenticationServices so the
-app can cancel an `ASWebAuthenticationSession` when its three-minute deadline
-expires.
+Android runs OAuth2 sessions through `flutter_web_auth_2`. iOS and macOS use a
+small app-owned bridge to AuthenticationServices so the app can cancel an
+`ASWebAuthenticationSession` when its three-minute deadline expires.
+AuthenticationServices retains the Apple-platform browser session and delivers
+the matching HTTPS callback directly to the app.
 
 Windows and Linux open the system browser and use a temporary loopback
 callback URL:
@@ -12,10 +13,11 @@ callback URL:
 http://127.0.0.1:{port}/oauth2/callback
 ```
 
-The package owns the loopback HTTP listener. SyncTV probes an available port,
-passes the resulting redirect URL to the backend, and retries the complete
-authorization start when another process claims that port before the listener
-starts.
+SyncTV binds the loopback HTTP listener before requesting the provider's
+authorization URL and retains it for the complete authorization flow. This
+removes the port race between choosing a callback URL and receiving the browser
+redirect. SyncTV closes the listener on completion or failure and brings the
+desktop window to the foreground after a valid callback.
 
 Browser-based OAuth authorization on Android, iOS, and macOS uses an HTTPS
 callback. Android opens an AndroidX Auth Tab. iOS and macOS open

--- a/lib/features/auth/application/oauth2_callback_client.dart
+++ b/lib/features/auth/application/oauth2_callback_client.dart
@@ -13,6 +13,8 @@ abstract interface class OAuth2CallbackSession {
     required Uri authorizationUrl,
     required String expectedState,
   });
+
+  Future<void> close();
 }
 
 Future<T> withOAuth2CallbackSession<T>(
@@ -27,11 +29,14 @@ Future<T> withOAuth2CallbackSession<T>(
   var attempt = 0;
   while (true) {
     attempt++;
+    OAuth2CallbackSession? session;
     try {
-      final session = await client.createSession();
+      session = await client.createSession();
       return await operation(session);
     } on OAuth2CallbackBindFailed {
       if (attempt >= maxBindAttempts) rethrow;
+    } finally {
+      await session?.close();
     }
   }
 }

--- a/lib/features/auth/infrastructure/oauth2_callback_service.dart
+++ b/lib/features/auth/infrastructure/oauth2_callback_service.dart
@@ -10,6 +10,7 @@ import 'package:synctv_app/features/auth/application/native_apple_sign_in_client
 import 'package:synctv_app/features/auth/domain/oauth2_callback_config.dart';
 import 'package:synctv_app/features/auth/domain/oauth2_callback_parser.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:window_to_front/window_to_front.dart';
 
 enum OAuth2CallbackTransport {
   flutterWebAuth2,
@@ -43,6 +44,8 @@ class OAuth2CallbackService {
 
   static Future<OAuth2CallbackSession> createSession({
     Future<bool> Function(Uri authorizationUrl)? launchExternalUrl,
+    Future<void> Function()? activateAppWindow,
+    Duration authorizationTimeout = oauth2AuthorizationTimeout,
   }) async {
     final platform = defaultTargetPlatform;
     final transport = callbackTransportFor(platform);
@@ -56,18 +59,8 @@ class OAuth2CallbackService {
     HttpServer? loopbackServer;
     if (transport == OAuth2CallbackTransport.loopbackHttpServer) {
       try {
-        loopbackServer = await HttpServer.bind(
-          InternetAddress.loopbackIPv4,
-          0,
-        );
+        loopbackServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
         redirectUri = loopbackRedirectUriForPort(loopbackServer.port);
-      } on SocketException catch (error) {
-        throw OAuth2CallbackBindFailed(error);
-      }
-    } else if (usesLoopbackCallback(platform)) {
-      try {
-        final port = await _findAvailableLoopbackPort();
-        redirectUri = loopbackRedirectUriForPort(port);
       } on SocketException catch (error) {
         throw OAuth2CallbackBindFailed(error);
       }
@@ -79,15 +72,16 @@ class OAuth2CallbackService {
       OAuth2CallbackTransport.flutterWebAuth2 =>
         _FlutterWebAuth2CallbackSession(
           redirectUri: redirectUri,
-          usesLoopbackCallback: usesLoopbackCallback(platform),
-          callbackUrlScheme: callbackUrlSchemeFor(platform, redirectUri),
-          options: optionsFor(platform, redirectUri),
+          callbackUrlScheme: callbackUrlSchemeFor(redirectUri),
+          options: optionsFor(redirectUri),
         ),
       OAuth2CallbackTransport.loopbackHttpServer =>
         _LoopbackHttpCallbackSession(
           server: loopbackServer!,
           redirectUri: redirectUri,
           launchExternalUrl: launchExternalUrl ?? _launchExternalUrl,
+          activateAppWindow: activateAppWindow ?? _activateAppWindow,
+          authorizationTimeout: authorizationTimeout,
         ),
       OAuth2CallbackTransport.darwinAuthenticationSession =>
         _DarwinOAuth2CallbackSession(redirectUri),
@@ -100,9 +94,9 @@ class OAuth2CallbackService {
   @visibleForTesting
   static OAuth2CallbackTransport callbackTransportFor(TargetPlatform platform) {
     return switch (platform) {
-      TargetPlatform.android || TargetPlatform.linux =>
-        OAuth2CallbackTransport.flutterWebAuth2,
-      TargetPlatform.windows => OAuth2CallbackTransport.loopbackHttpServer,
+      TargetPlatform.android => OAuth2CallbackTransport.flutterWebAuth2,
+      TargetPlatform.windows ||
+      TargetPlatform.linux => OAuth2CallbackTransport.loopbackHttpServer,
       TargetPlatform.iOS || TargetPlatform.macOS =>
         OAuth2CallbackTransport.darwinAuthenticationSession,
       TargetPlatform.fuchsia => OAuth2CallbackTransport.unsupported,
@@ -137,58 +131,39 @@ class OAuth2CallbackService {
   }
 
   @visibleForTesting
-  static String callbackUrlSchemeFor(TargetPlatform platform, Uri redirectUri) {
-    return usesLoopbackCallback(platform)
-        ? redirectUri.toString()
-        : redirectUri.scheme;
-  }
+  static String callbackUrlSchemeFor(Uri redirectUri) => redirectUri.scheme;
 
   @visibleForTesting
-  static FlutterWebAuth2Options optionsFor(
-    TargetPlatform platform,
-    Uri redirectUri,
-  ) {
-    if (usesLoopbackCallback(platform)) {
-      return const FlutterWebAuth2Options(
-        useWebview: false,
-        timeout: 5 * 60,
-        landingPageHtml: _loopbackLandingPage,
-      );
-    }
+  static FlutterWebAuth2Options optionsFor(Uri redirectUri) {
     return FlutterWebAuth2Options(
       httpsHost: redirectUri.host,
       httpsPath: redirectUri.path,
     );
   }
 
-  static Future<int> _findAvailableLoopbackPort() async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    try {
-      return server.port;
-    } finally {
-      await server.close(force: true);
-    }
+  static Future<bool> _launchExternalUrl(Uri authorizationUrl) {
+    return launchUrl(authorizationUrl, mode: LaunchMode.externalApplication);
   }
 
-  static Future<bool> _launchExternalUrl(Uri authorizationUrl) {
-    return launchUrl(
-      authorizationUrl,
-      mode: LaunchMode.externalApplication,
-    );
-  }
+  static Future<void> _activateAppWindow() => WindowToFront.activate();
 }
 
 final class _LoopbackHttpCallbackSession implements OAuth2CallbackSession {
   _LoopbackHttpCallbackSession({
-    required HttpServer server,
+    required this._server,
     required this.redirectUri,
     required this.launchExternalUrl,
-  }) : _server = server;
+    required this.activateAppWindow,
+    required this.authorizationTimeout,
+  });
 
   final HttpServer _server;
   final Uri redirectUri;
   final Future<bool> Function(Uri authorizationUrl) launchExternalUrl;
-  bool _closed = false;
+  final Future<void> Function() activateAppWindow;
+  final Duration authorizationTimeout;
+  Future<void>? _closeFuture;
+  bool _callbackAccepted = false;
 
   @override
   String get redirectUrl => redirectUri.toString();
@@ -198,73 +173,209 @@ final class _LoopbackHttpCallbackSession implements OAuth2CallbackSession {
     required Uri authorizationUrl,
     required String expectedState,
   }) async {
-    try {
-      final callbackRequest = _server.first;
-      if (!await launchExternalUrl(authorizationUrl)) {
-        callbackRequest.ignore();
-        throw PlatformException(
-          code: 'LAUNCH_FAILED',
-          message: 'The system browser could not be opened',
-        );
-      }
-
-      late final HttpRequest request;
-      try {
-        request = await callbackRequest.timeout(oauth2AuthorizationTimeout);
-      } on TimeoutException {
-        throw const OAuth2AuthorizationTimedOut();
-      }
-
-      if (request.uri.path != redirectUri.path) {
-        request.response.statusCode = HttpStatus.notFound;
-        await request.response.close();
-        throw ArgumentError.value(
-          request.uri.path,
-          'callbackPath',
-          'Unexpected OAuth2 callback path',
-        );
-      }
-
-      late final OAuth2CallbackPayload payload;
-      try {
-        payload = OAuth2CallbackParser.parse(
-          request.requestedUri,
+    final callback = Completer<_LoopbackCallbackResult>();
+    final requests = _server.listen(
+      (request) => unawaited(
+        _handleRequest(
+          request,
           expectedState: expectedState,
-        );
-      } catch (_) {
-        request.response.statusCode = HttpStatus.badRequest;
-        request.response.write('Invalid OAuth2 callback.');
-        await request.response.close();
-        rethrow;
+          callback: callback,
+        ).catchError((Object error, StackTrace stackTrace) {
+          if (!callback.isCompleted) {
+            callback.completeError(error, stackTrace);
+            return;
+          }
+          debugPrint('Failed to handle an OAuth2 callback request: $error');
+        }),
+      ),
+      onError: (Object error, StackTrace stackTrace) {
+        if (!callback.isCompleted) callback.completeError(error, stackTrace);
+      },
+      onDone: () {
+        if (!callback.isCompleted) {
+          callback.completeError(const OAuth2AuthorizationCanceled());
+        }
+      },
+    );
+    try {
+      final launch = () async {
+        final launched = await launchExternalUrl(authorizationUrl);
+        if (!launched) {
+          throw PlatformException(
+            code: 'LAUNCH_FAILED',
+            message: 'The system browser could not be opened',
+          );
+        }
+      }();
+      final results =
+          await Future.wait<Object?>([
+            launch,
+            callback.future,
+          ], eagerError: true).timeout(
+            authorizationTimeout,
+            onTimeout: () => throw const OAuth2AuthorizationTimedOut(),
+          );
+      final result = results[1]! as _LoopbackCallbackResult;
+      await close();
+      try {
+        await activateAppWindow();
+      } catch (error) {
+        debugPrint('Failed to activate the app after OAuth2 callback: $error');
       }
-
-      request.response.headers.contentType = ContentType.html;
-      request.response.write(OAuth2CallbackService._loopbackLandingPage);
-      await request.response.close();
-      return payload;
+      return switch (result) {
+        _LoopbackCallbackSuccess(:final payload) => payload,
+        _LoopbackCallbackFailure(:final error, :final stackTrace) =>
+          Error.throwWithStackTrace(error, stackTrace),
+      };
     } finally {
+      await requests.cancel();
       await close();
     }
   }
 
-  @override
-  Future<void> close() async {
-    if (_closed) return;
-    _closed = true;
-    await _server.close(force: true);
+  Future<void> _handleRequest(
+    HttpRequest request, {
+    required String expectedState,
+    required Completer<_LoopbackCallbackResult> callback,
+  }) async {
+    if (request.uri.path != redirectUri.path) {
+      await _respond(request, HttpStatus.notFound, 'Not found.');
+      return;
+    }
+
+    final parameters = request.uri.queryParameters;
+    final authorizationError = parameters['error']?.trim() ?? '';
+    if (authorizationError.isNotEmpty) {
+      final state = parameters['state']?.trim() ?? '';
+      if (state.isEmpty ||
+          (expectedState.isNotEmpty && state != expectedState)) {
+        await _respond(
+          request,
+          HttpStatus.badRequest,
+          'Invalid OAuth2 callback.',
+        );
+        return;
+      }
+      if (_callbackAccepted) {
+        await _respond(
+          request,
+          HttpStatus.conflict,
+          'Callback already received.',
+        );
+        return;
+      }
+      _callbackAccepted = true;
+      await _respond(
+        request,
+        HttpStatus.ok,
+        'OAuth2 authorization was canceled.',
+      );
+      if (!callback.isCompleted) {
+        if (authorizationError == 'access_denied') {
+          callback.complete(
+            _LoopbackCallbackFailure(
+              const OAuth2AuthorizationCanceled(),
+              StackTrace.current,
+            ),
+          );
+        } else {
+          final description = parameters['error_description']?.trim();
+          callback.complete(
+            _LoopbackCallbackFailure(
+              PlatformException(
+                code: 'AUTHORIZATION_FAILED',
+                message: description == null || description.isEmpty
+                    ? authorizationError
+                    : description,
+                details: authorizationError,
+              ),
+              StackTrace.current,
+            ),
+          );
+        }
+      }
+      return;
+    }
+
+    late final OAuth2CallbackPayload payload;
+    try {
+      payload = OAuth2CallbackParser.parse(
+        request.requestedUri,
+        expectedState: expectedState,
+      );
+    } on ArgumentError {
+      await _respond(
+        request,
+        HttpStatus.badRequest,
+        'Invalid OAuth2 callback.',
+      );
+      return;
+    }
+
+    if (_callbackAccepted) {
+      await _respond(
+        request,
+        HttpStatus.conflict,
+        'Callback already received.',
+      );
+      return;
+    }
+    _callbackAccepted = true;
+
+    try {
+      request.response.headers.contentType = ContentType.html;
+      request.response.write(OAuth2CallbackService._loopbackLandingPage);
+      await request.response.close();
+    } on IOException catch (error) {
+      debugPrint('Failed to send the OAuth2 landing page: $error');
+    }
+    if (!callback.isCompleted) {
+      callback.complete(_LoopbackCallbackSuccess(payload));
+    }
   }
+
+  Future<void> _respond(HttpRequest request, int status, String body) async {
+    try {
+      request.response.statusCode = status;
+      request.response.write(body);
+      await request.response.close();
+    } on IOException {
+      // The client can disconnect after delivering a request. A later valid
+      // OAuth callback must remain eligible to complete the session.
+    }
+  }
+
+  @override
+  Future<void> close() => _closeFuture ??= _closeServer();
+
+  Future<void> _closeServer() async => _server.close(force: true);
+}
+
+sealed class _LoopbackCallbackResult {
+  const _LoopbackCallbackResult();
+}
+
+final class _LoopbackCallbackSuccess extends _LoopbackCallbackResult {
+  const _LoopbackCallbackSuccess(this.payload);
+
+  final OAuth2CallbackPayload payload;
+}
+
+final class _LoopbackCallbackFailure extends _LoopbackCallbackResult {
+  const _LoopbackCallbackFailure(this.error, this.stackTrace);
+
+  final Object error;
+  final StackTrace stackTrace;
 }
 
 final class _FlutterWebAuth2CallbackSession implements OAuth2CallbackSession {
   const _FlutterWebAuth2CallbackSession({
     required this.redirectUri,
-    required this.usesLoopbackCallback,
     required this.callbackUrlScheme,
     required this.options,
   });
 
   final Uri redirectUri;
-  final bool usesLoopbackCallback;
   final String callbackUrlScheme;
   final FlutterWebAuth2Options options;
 
@@ -290,11 +401,6 @@ final class _FlutterWebAuth2CallbackSession implements OAuth2CallbackSession {
         Uri.parse(callback),
         expectedState: expectedState,
       );
-    } on SocketException catch (error) {
-      if (usesLoopbackCallback) {
-        throw OAuth2CallbackBindFailed(error);
-      }
-      rethrow;
     } on PlatformException catch (error) {
       if (error.code == 'CANCELED') {
         throw const OAuth2AuthorizationCanceled();

--- a/lib/features/auth/infrastructure/oauth2_callback_service.dart
+++ b/lib/features/auth/infrastructure/oauth2_callback_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -8,9 +9,11 @@ import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart
 import 'package:synctv_app/features/auth/application/native_apple_sign_in_client.dart';
 import 'package:synctv_app/features/auth/domain/oauth2_callback_config.dart';
 import 'package:synctv_app/features/auth/domain/oauth2_callback_parser.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 enum OAuth2CallbackTransport {
   flutterWebAuth2,
+  loopbackHttpServer,
   darwinAuthenticationSession,
   unsupported,
 }
@@ -38,7 +41,9 @@ class OAuth2CallbackService {
     hasMobileOrigin: OAuth2CallbackConfig.hasMobileOrigin,
   );
 
-  static Future<OAuth2CallbackSession> createSession() async {
+  static Future<OAuth2CallbackSession> createSession({
+    Future<bool> Function(Uri authorizationUrl)? launchExternalUrl,
+  }) async {
     final platform = defaultTargetPlatform;
     final transport = callbackTransportFor(platform);
     if (transport == OAuth2CallbackTransport.unsupported) {
@@ -48,15 +53,21 @@ class OAuth2CallbackService {
     }
 
     late final Uri redirectUri;
-    if (usesLoopbackCallback(platform)) {
+    HttpServer? loopbackServer;
+    if (transport == OAuth2CallbackTransport.loopbackHttpServer) {
+      try {
+        loopbackServer = await HttpServer.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        redirectUri = loopbackRedirectUriForPort(loopbackServer.port);
+      } on SocketException catch (error) {
+        throw OAuth2CallbackBindFailed(error);
+      }
+    } else if (usesLoopbackCallback(platform)) {
       try {
         final port = await _findAvailableLoopbackPort();
-        redirectUri = Uri(
-          scheme: 'http',
-          host: InternetAddress.loopbackIPv4.address,
-          port: port,
-          path: '/oauth2/callback',
-        );
+        redirectUri = loopbackRedirectUriForPort(port);
       } on SocketException catch (error) {
         throw OAuth2CallbackBindFailed(error);
       }
@@ -72,6 +83,12 @@ class OAuth2CallbackService {
           callbackUrlScheme: callbackUrlSchemeFor(platform, redirectUri),
           options: optionsFor(platform, redirectUri),
         ),
+      OAuth2CallbackTransport.loopbackHttpServer =>
+        _LoopbackHttpCallbackSession(
+          server: loopbackServer!,
+          redirectUri: redirectUri,
+          launchExternalUrl: launchExternalUrl ?? _launchExternalUrl,
+        ),
       OAuth2CallbackTransport.darwinAuthenticationSession =>
         _DarwinOAuth2CallbackSession(redirectUri),
       OAuth2CallbackTransport.unsupported => throw StateError(
@@ -83,9 +100,9 @@ class OAuth2CallbackService {
   @visibleForTesting
   static OAuth2CallbackTransport callbackTransportFor(TargetPlatform platform) {
     return switch (platform) {
-      TargetPlatform.android ||
-      TargetPlatform.linux ||
-      TargetPlatform.windows => OAuth2CallbackTransport.flutterWebAuth2,
+      TargetPlatform.android || TargetPlatform.linux =>
+        OAuth2CallbackTransport.flutterWebAuth2,
+      TargetPlatform.windows => OAuth2CallbackTransport.loopbackHttpServer,
       TargetPlatform.iOS || TargetPlatform.macOS =>
         OAuth2CallbackTransport.darwinAuthenticationSession,
       TargetPlatform.fuchsia => OAuth2CallbackTransport.unsupported,
@@ -107,6 +124,16 @@ class OAuth2CallbackService {
   static bool usesLoopbackCallback(TargetPlatform platform) {
     return platform == TargetPlatform.windows ||
         platform == TargetPlatform.linux;
+  }
+
+  @visibleForTesting
+  static Uri loopbackRedirectUriForPort(int port) {
+    return Uri(
+      scheme: 'http',
+      host: InternetAddress.loopbackIPv4.address,
+      port: port,
+      path: '/oauth2/callback',
+    );
   }
 
   @visibleForTesting
@@ -141,6 +168,90 @@ class OAuth2CallbackService {
     } finally {
       await server.close(force: true);
     }
+  }
+
+  static Future<bool> _launchExternalUrl(Uri authorizationUrl) {
+    return launchUrl(
+      authorizationUrl,
+      mode: LaunchMode.externalApplication,
+    );
+  }
+}
+
+final class _LoopbackHttpCallbackSession implements OAuth2CallbackSession {
+  _LoopbackHttpCallbackSession({
+    required HttpServer server,
+    required this.redirectUri,
+    required this.launchExternalUrl,
+  }) : _server = server;
+
+  final HttpServer _server;
+  final Uri redirectUri;
+  final Future<bool> Function(Uri authorizationUrl) launchExternalUrl;
+  bool _closed = false;
+
+  @override
+  String get redirectUrl => redirectUri.toString();
+
+  @override
+  Future<OAuth2CallbackPayload> authorize({
+    required Uri authorizationUrl,
+    required String expectedState,
+  }) async {
+    try {
+      final callbackRequest = _server.first;
+      if (!await launchExternalUrl(authorizationUrl)) {
+        callbackRequest.ignore();
+        throw PlatformException(
+          code: 'LAUNCH_FAILED',
+          message: 'The system browser could not be opened',
+        );
+      }
+
+      late final HttpRequest request;
+      try {
+        request = await callbackRequest.timeout(oauth2AuthorizationTimeout);
+      } on TimeoutException {
+        throw const OAuth2AuthorizationTimedOut();
+      }
+
+      if (request.uri.path != redirectUri.path) {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+        throw ArgumentError.value(
+          request.uri.path,
+          'callbackPath',
+          'Unexpected OAuth2 callback path',
+        );
+      }
+
+      late final OAuth2CallbackPayload payload;
+      try {
+        payload = OAuth2CallbackParser.parse(
+          request.requestedUri,
+          expectedState: expectedState,
+        );
+      } catch (_) {
+        request.response.statusCode = HttpStatus.badRequest;
+        request.response.write('Invalid OAuth2 callback.');
+        await request.response.close();
+        rethrow;
+      }
+
+      request.response.headers.contentType = ContentType.html;
+      request.response.write(OAuth2CallbackService._loopbackLandingPage);
+      await request.response.close();
+      return payload;
+    } finally {
+      await close();
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await _server.close(force: true);
   }
 }
 
@@ -191,6 +302,9 @@ final class _FlutterWebAuth2CallbackSession implements OAuth2CallbackSession {
       rethrow;
     }
   }
+
+  @override
+  Future<void> close() async {}
 }
 
 final class _DarwinOAuth2CallbackSession implements OAuth2CallbackSession {
@@ -238,6 +352,9 @@ final class _DarwinOAuth2CallbackSession implements OAuth2CallbackSession {
       }
     }
   }
+
+  @override
+  Future<void> close() async {}
 }
 
 /// Starts Apple's first-party Authentication Services flow. The native

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1391,7 +1391,7 @@ packages:
     source: hosted
     version: "0.5.2"
   window_to_front:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: window_to_front
       sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   desktop_webview_window: ^0.3.0
   media_kit_libs_macos_video: ^1.1.4
   window_manager: ^0.5.2
+  window_to_front: ^0.0.4
   forui: ^0.25.0
   flex_color_scheme: ^8.4.0
   responsive_framework: ^1.5.1

--- a/test/features/auth/application/oauth2_callback_client_test.dart
+++ b/test/features/auth/application/oauth2_callback_client_test.dart
@@ -15,6 +15,7 @@ void main() {
 
       expect(result, 'complete');
       expect(client.createCount, 1);
+      expect(session.closeCount, 1);
     });
 
     test('preserves ordinary operation failures without retrying', () async {
@@ -29,6 +30,7 @@ void main() {
         throwsStateError,
       );
       expect(client.createCount, 1);
+      expect(session.closeCount, 1);
     });
 
     test('creates a fresh session after a callback bind failure', () async {
@@ -47,6 +49,8 @@ void main() {
 
       expect(result, contains('second'));
       expect(client.createCount, 2);
+      expect(first.closeCount, 1);
+      expect(second.closeCount, 1);
     });
 
     test('stops retrying after the configured bind attempt limit', () async {
@@ -65,6 +69,9 @@ void main() {
         throwsA(isA<OAuth2CallbackBindFailed>()),
       );
       expect(client.createCount, 2);
+      for (final session in sessions) {
+        expect(session.closeCount, 1);
+      }
     });
 
     test('rejects an empty bind attempt budget', () async {
@@ -104,6 +111,7 @@ final class _FakeOAuth2CallbackSession implements OAuth2CallbackSession {
   _FakeOAuth2CallbackSession(this.name);
 
   final String name;
+  int closeCount = 0;
 
   @override
   String get redirectUrl => 'https://syncs.tv/oauth2/callback?session=$name';
@@ -113,4 +121,9 @@ final class _FakeOAuth2CallbackSession implements OAuth2CallbackSession {
     required Uri authorizationUrl,
     required String expectedState,
   }) async => OAuth2CallbackPayload(code: 'code', state: expectedState);
+
+  @override
+  Future<void> close() async {
+    closeCount++;
+  }
 }

--- a/test/features/auth/infrastructure/oauth2_callback_service_test.dart
+++ b/test/features/auth/infrastructure/oauth2_callback_service_test.dart
@@ -1,20 +1,30 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:synctv_app/features/auth/infrastructure/oauth2_callback_service.dart';
 
 void main() {
   group('OAuth2CallbackService callback transport', () {
-    test('uses flutter_web_auth_2 on Android, Windows, and Linux', () {
+    test('uses flutter_web_auth_2 on Android and Linux', () {
       for (final platform in <TargetPlatform>[
         TargetPlatform.android,
         TargetPlatform.linux,
-        TargetPlatform.windows,
       ]) {
         expect(
           OAuth2CallbackService.callbackTransportFor(platform),
           OAuth2CallbackTransport.flutterWebAuth2,
         );
       }
+    });
+
+    test('uses an owned loopback HTTP server on Windows', () {
+      expect(
+        OAuth2CallbackService.callbackTransportFor(TargetPlatform.windows),
+        OAuth2CallbackTransport.loopbackHttpServer,
+      );
     });
 
     test('uses cancellable AuthenticationServices sessions on Apple', () {
@@ -58,6 +68,74 @@ void main() {
       }
     });
 
+    test('creates IPv4 desktop callback URIs', () async {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      for (final platform in <TargetPlatform>[
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      ]) {
+        debugDefaultTargetPlatformOverride = platform;
+
+        final session = await OAuth2CallbackService.createSession();
+        try {
+          final redirectUri = Uri.parse(session.redirectUrl);
+
+          expect(redirectUri.scheme, 'http');
+          expect(redirectUri.host, '127.0.0.1');
+          expect(redirectUri.port, greaterThan(0));
+          expect(redirectUri.path, '/oauth2/callback');
+        } finally {
+          await session.close();
+        }
+      }
+    });
+
+    test('receives and closes a Windows loopback callback', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final browserLaunched = Completer<void>();
+      late Uri launchedAuthorizationUrl;
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (authorizationUrl) async {
+          launchedAuthorizationUrl = authorizationUrl;
+          browserLaunched.complete();
+          return true;
+        },
+      );
+      addTearDown(session.close);
+
+      const expectedState = 'expected-state';
+      final authorizationUrl = Uri.parse(
+        'https://auth.example.com/authorize',
+      );
+      final authorization = session.authorize(
+        authorizationUrl: authorizationUrl,
+        expectedState: expectedState,
+      );
+      await browserLaunched.future;
+      expect(launchedAuthorizationUrl, authorizationUrl);
+
+      final callbackUri = Uri.parse(session.redirectUrl).replace(
+        queryParameters: const {
+          'code': 'authorization-code',
+          'state': expectedState,
+        },
+      );
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final request = await client.getUrl(callbackUri);
+      final response = await request.close();
+      final responseBody = await utf8.decoder.bind(response).join();
+
+      final payload = await authorization;
+      expect(response.statusCode, HttpStatus.ok);
+      expect(responseBody, contains('SyncTV'));
+      expect(payload.code, 'authorization-code');
+      expect(payload.state, expectedState);
+    });
+
     test('requires a callback origin on Android and Apple platforms', () {
       for (final platform in <TargetPlatform>[
         TargetPlatform.android,
@@ -81,22 +159,23 @@ void main() {
       }
     });
 
-    test('uses a system browser and full loopback URL on desktop', () {
+    test('uses a system browser and full loopback URL on Linux', () {
       final redirectUri = Uri.parse('http://127.0.0.1:49152/oauth2/callback');
-
-      for (final platform in <TargetPlatform>[
-        TargetPlatform.windows,
+      final options = OAuth2CallbackService.optionsFor(
         TargetPlatform.linux,
-      ]) {
-        final options = OAuth2CallbackService.optionsFor(platform, redirectUri);
-        expect(
-          OAuth2CallbackService.callbackUrlSchemeFor(platform, redirectUri),
-          redirectUri.toString(),
-        );
-        expect(options.useWebview, isFalse);
-        expect(options.timeout, 300);
-        expect(options.landingPageHtml, contains('SyncTV'));
-      }
+        redirectUri,
+      );
+
+      expect(
+        OAuth2CallbackService.callbackUrlSchemeFor(
+          TargetPlatform.linux,
+          redirectUri,
+        ),
+        redirectUri.toString(),
+      );
+      expect(options.useWebview, isFalse);
+      expect(options.timeout, 300);
+      expect(options.landingPageHtml, contains('SyncTV'));
     });
 
     test('uses HTTPS host and path options on mobile and Apple platforms', () {

--- a/test/features/auth/infrastructure/oauth2_callback_service_test.dart
+++ b/test/features/auth/infrastructure/oauth2_callback_service_test.dart
@@ -3,28 +3,30 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart';
 import 'package:synctv_app/features/auth/infrastructure/oauth2_callback_service.dart';
 
 void main() {
   group('OAuth2CallbackService callback transport', () {
-    test('uses flutter_web_auth_2 on Android and Linux', () {
+    test('uses flutter_web_auth_2 on Android', () {
+      expect(
+        OAuth2CallbackService.callbackTransportFor(TargetPlatform.android),
+        OAuth2CallbackTransport.flutterWebAuth2,
+      );
+    });
+
+    test('uses an owned loopback HTTP server on desktop platforms', () {
       for (final platform in <TargetPlatform>[
-        TargetPlatform.android,
+        TargetPlatform.windows,
         TargetPlatform.linux,
       ]) {
         expect(
           OAuth2CallbackService.callbackTransportFor(platform),
-          OAuth2CallbackTransport.flutterWebAuth2,
+          OAuth2CallbackTransport.loopbackHttpServer,
         );
       }
-    });
-
-    test('uses an owned loopback HTTP server on Windows', () {
-      expect(
-        OAuth2CallbackService.callbackTransportFor(TargetPlatform.windows),
-        OAuth2CallbackTransport.loopbackHttpServer,
-      );
     });
 
     test('uses cancellable AuthenticationServices sessions on Apple', () {
@@ -68,72 +70,372 @@ void main() {
       }
     });
 
-    test('creates IPv4 desktop callback URIs', () async {
+    test(
+      'retains each desktop callback port until the session closes',
+      () async {
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        for (final platform in <TargetPlatform>[
+          TargetPlatform.windows,
+          TargetPlatform.linux,
+        ]) {
+          debugDefaultTargetPlatformOverride = platform;
+
+          final session = await OAuth2CallbackService.createSession();
+          try {
+            final redirectUri = Uri.parse(session.redirectUrl);
+
+            expect(redirectUri.scheme, 'http');
+            expect(redirectUri.host, '127.0.0.1');
+            expect(redirectUri.port, greaterThan(0));
+            expect(redirectUri.path, '/oauth2/callback');
+            await expectLater(
+              HttpServer.bind(InternetAddress.loopbackIPv4, redirectUri.port),
+              throwsA(isA<SocketException>()),
+            );
+          } finally {
+            await session.close();
+          }
+
+          final rebound = await HttpServer.bind(
+            InternetAddress.loopbackIPv4,
+            Uri.parse(session.redirectUrl).port,
+          );
+          await rebound.close(force: true);
+        }
+      },
+    );
+
+    for (final platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+    ]) {
+      test(
+        'receives, closes, and activates after a $platform callback',
+        () async {
+          debugDefaultTargetPlatformOverride = platform;
+          addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+          final browserLaunched = Completer<void>();
+          final appActivated = Completer<void>();
+          late Uri launchedAuthorizationUrl;
+          final session = await OAuth2CallbackService.createSession(
+            launchExternalUrl: (authorizationUrl) async {
+              launchedAuthorizationUrl = authorizationUrl;
+              browserLaunched.complete();
+              return true;
+            },
+            activateAppWindow: () async => appActivated.complete(),
+          );
+          addTearDown(session.close);
+
+          const expectedState = 'expected-state';
+          final authorizationUrl = Uri.parse(
+            'https://auth.example.com/authorize',
+          );
+          final authorization = session.authorize(
+            authorizationUrl: authorizationUrl,
+            expectedState: expectedState,
+          );
+          await browserLaunched.future;
+          expect(launchedAuthorizationUrl, authorizationUrl);
+
+          final callbackUri = Uri.parse(session.redirectUrl).replace(
+            queryParameters: const {
+              'code': 'authorization-code',
+              'state': expectedState,
+            },
+          );
+          final client = HttpClient();
+          addTearDown(() => client.close(force: true));
+          final request = await client.getUrl(callbackUri);
+          final response = await request.close();
+          final responseBody = await utf8.decoder.bind(response).join();
+
+          final payload = await authorization;
+          await appActivated.future;
+          expect(response.statusCode, HttpStatus.ok);
+          expect(responseBody, contains('SyncTV'));
+          expect(payload.code, 'authorization-code');
+          expect(payload.state, expectedState);
+
+          final rebound = await HttpServer.bind(
+            InternetAddress.loopbackIPv4,
+            callbackUri.port,
+          );
+          await rebound.close(force: true);
+        },
+      );
+    }
+
+    test(
+      'keeps a valid callback result when window activation fails',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        final browserLaunched = Completer<void>();
+        final session = await OAuth2CallbackService.createSession(
+          launchExternalUrl: (_) async {
+            browserLaunched.complete();
+            return true;
+          },
+          activateAppWindow: () async => throw StateError('focus failed'),
+        );
+        addTearDown(session.close);
+
+        final authorization = session.authorize(
+          authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+          expectedState: 'expected-state',
+        );
+        await browserLaunched.future;
+        final callbackUri = Uri.parse(session.redirectUrl).replace(
+          queryParameters: const {
+            'code': 'authorization-code',
+            'state': 'expected-state',
+          },
+        );
+        final client = HttpClient();
+        addTearDown(() => client.close(force: true));
+        final response = await (await client.getUrl(callbackUri)).close();
+        await response.drain<void>();
+
+        final payload = await authorization;
+        expect(payload.code, 'authorization-code');
+      },
+    );
+
+    test('continues waiting after unrelated and invalid callbacks', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
-      for (final platform in <TargetPlatform>[
-        TargetPlatform.windows,
-        TargetPlatform.linux,
-      ]) {
-        debugDefaultTargetPlatformOverride = platform;
+      final browserLaunched = Completer<void>();
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (_) async {
+          browserLaunched.complete();
+          return true;
+        },
+        activateAppWindow: () async {},
+      );
+      addTearDown(session.close);
 
-        final session = await OAuth2CallbackService.createSession();
-        try {
-          final redirectUri = Uri.parse(session.redirectUrl);
+      final authorization = session.authorize(
+        authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+        expectedState: 'expected-state',
+      );
+      await browserLaunched.future;
 
-          expect(redirectUri.scheme, 'http');
-          expect(redirectUri.host, '127.0.0.1');
-          expect(redirectUri.port, greaterThan(0));
-          expect(redirectUri.path, '/oauth2/callback');
-        } finally {
-          await session.close();
-        }
-      }
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+      final redirectUri = Uri.parse(session.redirectUrl);
+
+      final unrelatedResponse = await (await client.getUrl(
+        redirectUri.replace(path: '/favicon.ico'),
+      )).close();
+      await unrelatedResponse.drain<void>();
+      expect(unrelatedResponse.statusCode, HttpStatus.notFound);
+
+      final invalidResponse = await (await client.getUrl(
+        redirectUri.replace(
+          queryParameters: const {'code': 'stale-code', 'state': 'stale-state'},
+        ),
+      )).close();
+      await invalidResponse.drain<void>();
+      expect(invalidResponse.statusCode, HttpStatus.badRequest);
+
+      final invalidErrorResponse = await (await client.getUrl(
+        redirectUri.replace(
+          queryParameters: const {
+            'error': 'access_denied',
+            'state': 'stale-state',
+          },
+        ),
+      )).close();
+      await invalidErrorResponse.drain<void>();
+      expect(invalidErrorResponse.statusCode, HttpStatus.badRequest);
+
+      final validResponse = await (await client.getUrl(
+        redirectUri.replace(
+          queryParameters: const {
+            'code': 'authorization-code',
+            'state': 'expected-state',
+          },
+        ),
+      )).close();
+      await validResponse.drain<void>();
+
+      final payload = await authorization;
+      expect(validResponse.statusCode, HttpStatus.ok);
+      expect(payload.code, 'authorization-code');
+      expect(payload.state, 'expected-state');
     });
 
-    test('receives and closes a Windows loopback callback', () async {
+    test('maps a state-matched access denial to cancellation', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.windows;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
       final browserLaunched = Completer<void>();
-      late Uri launchedAuthorizationUrl;
+      final appActivated = Completer<void>();
       final session = await OAuth2CallbackService.createSession(
-        launchExternalUrl: (authorizationUrl) async {
-          launchedAuthorizationUrl = authorizationUrl;
+        launchExternalUrl: (_) async {
           browserLaunched.complete();
           return true;
         },
+        activateAppWindow: () async => appActivated.complete(),
       );
-      addTearDown(session.close);
-
-      const expectedState = 'expected-state';
-      final authorizationUrl = Uri.parse(
-        'https://auth.example.com/authorize',
-      );
+      final port = Uri.parse(session.redirectUrl).port;
       final authorization = session.authorize(
-        authorizationUrl: authorizationUrl,
-        expectedState: expectedState,
+        authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+        expectedState: 'expected-state',
       );
       await browserLaunched.future;
-      expect(launchedAuthorizationUrl, authorizationUrl);
 
       final callbackUri = Uri.parse(session.redirectUrl).replace(
         queryParameters: const {
-          'code': 'authorization-code',
-          'state': expectedState,
+          'error': 'access_denied',
+          'state': 'expected-state',
         },
       );
       final client = HttpClient();
       addTearDown(() => client.close(force: true));
-      final request = await client.getUrl(callbackUri);
-      final response = await request.close();
-      final responseBody = await utf8.decoder.bind(response).join();
+      final response = await (await client.getUrl(callbackUri)).close();
+      await response.drain<void>();
 
-      final payload = await authorization;
       expect(response.statusCode, HttpStatus.ok);
-      expect(responseBody, contains('SyncTV'));
-      expect(payload.code, 'authorization-code');
-      expect(payload.state, expectedState);
+      await expectLater(
+        authorization,
+        throwsA(isA<OAuth2AuthorizationCanceled>()),
+      );
+      await appActivated.future;
+      final rebound = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      await rebound.close(force: true);
+    });
+
+    test('closes the listener when the system browser cannot launch', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (_) async => false,
+        activateAppWindow: () async {},
+      );
+      final port = Uri.parse(session.redirectUrl).port;
+
+      await expectLater(
+        session.authorize(
+          authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+          expectedState: 'expected-state',
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (error) => error.code,
+            'code',
+            'LAUNCH_FAILED',
+          ),
+        ),
+      );
+
+      final rebound = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      await rebound.close(force: true);
+      await session.close();
+    });
+
+    test('cancels authorization when the session closes externally', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final browserLaunched = Completer<void>();
+      final browserLaunchResult = Completer<bool>();
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (_) {
+          browserLaunched.complete();
+          return browserLaunchResult.future;
+        },
+        activateAppWindow: () async {},
+      );
+      final authorization = session.authorize(
+        authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+        expectedState: 'expected-state',
+      );
+      await browserLaunched.future;
+
+      await session.close();
+
+      await expectLater(
+        authorization,
+        throwsA(isA<OAuth2AuthorizationCanceled>()),
+      );
+      browserLaunchResult.complete(true);
+    });
+
+    test('closes the listener after authorization times out', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (_) async => true,
+        activateAppWindow: () async {},
+        authorizationTimeout: const Duration(milliseconds: 20),
+      );
+      final port = Uri.parse(session.redirectUrl).port;
+
+      await expectLater(
+        session.authorize(
+          authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+          expectedState: 'expected-state',
+        ),
+        throwsA(isA<OAuth2AuthorizationTimedOut>()),
+      );
+
+      final rebound = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      await rebound.close(force: true);
+    });
+
+    test('includes browser launch in the authorization timeout', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final browserLaunchStarted = Completer<void>();
+      final browserLaunchResult = Completer<bool>();
+      final session = await OAuth2CallbackService.createSession(
+        launchExternalUrl: (_) {
+          browserLaunchStarted.complete();
+          return browserLaunchResult.future;
+        },
+        activateAppWindow: () async {},
+        authorizationTimeout: const Duration(milliseconds: 20),
+      );
+      final port = Uri.parse(session.redirectUrl).port;
+
+      final authorization = session.authorize(
+        authorizationUrl: Uri.parse('https://auth.example.com/authorize'),
+        expectedState: 'expected-state',
+      );
+      await browserLaunchStarted.future;
+      await expectLater(
+        authorization,
+        throwsA(isA<OAuth2AuthorizationTimedOut>()),
+      );
+
+      final rebound = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      await rebound.close(force: true);
+      browserLaunchResult.complete(true);
+    });
+
+    test('shares concurrent listener close operations', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final session = await OAuth2CallbackService.createSession();
+      final port = Uri.parse(session.redirectUrl).port;
+
+      final firstClose = session.close();
+      final secondClose = session.close();
+      expect(identical(firstClose, secondClose), isTrue);
+      await Future.wait([firstClose, secondClose]);
+
+      final rebound = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      await rebound.close(force: true);
     });
 
     test('requires a callback origin on Android and Apple platforms', () {
@@ -159,41 +461,13 @@ void main() {
       }
     });
 
-    test('uses a system browser and full loopback URL on Linux', () {
-      final redirectUri = Uri.parse('http://127.0.0.1:49152/oauth2/callback');
-      final options = OAuth2CallbackService.optionsFor(
-        TargetPlatform.linux,
-        redirectUri,
-      );
-
-      expect(
-        OAuth2CallbackService.callbackUrlSchemeFor(
-          TargetPlatform.linux,
-          redirectUri,
-        ),
-        redirectUri.toString(),
-      );
-      expect(options.useWebview, isFalse);
-      expect(options.timeout, 300);
-      expect(options.landingPageHtml, contains('SyncTV'));
-    });
-
     test('uses HTTPS host and path options on mobile and Apple platforms', () {
       final redirectUri = Uri.parse('https://app.syncs.tv/oauth2/callback');
+      final options = OAuth2CallbackService.optionsFor(redirectUri);
 
-      for (final platform in <TargetPlatform>[
-        TargetPlatform.android,
-        TargetPlatform.iOS,
-        TargetPlatform.macOS,
-      ]) {
-        final options = OAuth2CallbackService.optionsFor(platform, redirectUri);
-        expect(
-          OAuth2CallbackService.callbackUrlSchemeFor(platform, redirectUri),
-          'https',
-        );
-        expect(options.httpsHost, 'app.syncs.tv');
-        expect(options.httpsPath, '/oauth2/callback');
-      }
+      expect(OAuth2CallbackService.callbackUrlSchemeFor(redirectUri), 'https');
+      expect(options.httpsHost, 'app.syncs.tv');
+      expect(options.httpsPath, '/oauth2/callback');
     });
   });
 }


### PR DESCRIPTION
The desktop OAuth2 flow previously probed an available loopback port and released it before `flutter_web_auth_2` recreated the listener. A competing bind or a listener lifecycle failure could leave the browser callback pending until SyncTV timed out.

## Fix

- SyncTV now binds `127.0.0.1:0` before requesting the provider authorization URL on Windows and Linux.
- The listener remains owned by the OAuth session through success, provider rejection, timeout, external cancellation, and browser launch failure.
- Unrelated paths and callbacks with invalid state receive an HTTP error while the session continues waiting.
- A state-matched `access_denied` callback completes immediately as user cancellation.
- Valid callbacks close the listener and restore the desktop window.
- Android continues through `flutter_web_auth_2`.
- iOS and macOS continue through the app-owned `ASWebAuthenticationSession` bridge with HTTPS callbacks.

## Verification

- `flutter test`: 761 tests passed
- `dart analyze --fatal-infos`: no issues
- `dart format --output=none --set-exit-if-changed .`: 589 files, 0 changes
- `flutter build macos --debug --dart-define=SYNCTV_OAUTH2_APP_LINK_ORIGIN=https://app.example.com`: succeeded