### PR TITLE
fix(chat): retain input focus after sending

### DIFF
--- a/lib/features/room/presentation/widgets/chat_input_area.dart
+++ b/lib/features/room/presentation/widgets/chat_input_area.dart
@@ -13,7 +13,7 @@ class ChatInputArea extends StatefulWidget {
   final bool isVoiceInputMode;
   final bool isLoading;
   final String conversationType;
-  final VoidCallback onSendMessage;
+  final FutureOr<void> Function() onSendMessage;
   final VoidCallback onSwitchToVoiceMode;
   final VoidCallback onShowImagePicker;
   final Function onStartRecording;
@@ -250,7 +250,7 @@ class TextInputArea extends StatefulWidget {
   final bool hasText;
   final bool isLoading;
   final String conversationType;
-  final VoidCallback onSendMessage;
+  final FutureOr<void> Function() onSendMessage;
   final VoidCallback onShowImagePicker;
   final VoidCallback? onSwitchToVoiceMode;
   final Uint8List? selectedImageBytes;
@@ -458,6 +458,18 @@ class _TextInputAreaState extends State<TextInputArea> {
     return codeUnitOffset;
   }
 
+  Future<void> _sendMessage() async {
+    try {
+      await widget.onSendMessage();
+    } finally {
+      if (mounted) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _focusNode.requestFocus();
+        });
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -568,9 +580,7 @@ class _TextInputAreaState extends State<TextInputArea> {
                       keyboardType: TextInputType.multiline,
                       textInputAction: TextInputAction.send,
                       showClearButton: false,
-                      onSubmitted: canSend
-                          ? (_) => widget.onSendMessage()
-                          : null,
+                      onSubmitted: canSend ? (_) => _sendMessage() : null,
                       onChanged: (_) => _refreshInputState(),
                       onTap: widget.onInputFocused,
                       enabled: !widget.isLoading,
@@ -600,7 +610,7 @@ class _TextInputAreaState extends State<TextInputArea> {
                   SizedBox.square(
                     dimension: 44,
                     child: AppIconButton(
-                      onPressed: canSend ? widget.onSendMessage : null,
+                      onPressed: canSend ? _sendMessage : null,
                       icon: Icons.send_rounded,
                       tooltip: context.l10n.send,
                       loading: widget.isLoading,

--- a/test/features/room/presentation/widgets/chat_input_area_test.dart
+++ b/test/features/room/presentation/widgets/chat_input_area_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/features/room/presentation/widgets/chat_input_area.dart';
+import 'package:synctv_app/l10n/app_localizations.dart';
+
+import '../../../../test_app.dart';
+
+void main() {
+  for (final submitMethod in _SubmitMethod.values) {
+    testWidgets(
+      'keeps the message field focused after ${submitMethod.name} send',
+      (tester) async {
+        final sendCompleter = Completer<void>();
+        var sendCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: buildThemedTestApp,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: _ChatInputHarness(
+                onSend: () async {
+                  sendCount += 1;
+                  await sendCompleter.future;
+                },
+              ),
+            ),
+          ),
+        );
+
+        final field = find.byType(TextFormField);
+        await tester.enterText(field, 'Hello');
+        await tester.pump();
+        expect(_focusNode(tester, field).hasFocus, isTrue);
+
+        switch (submitMethod) {
+          case _SubmitMethod.button:
+            await tester.tap(find.byIcon(Icons.send_rounded));
+          case _SubmitMethod.keyboard:
+            await tester.testTextInput.receiveAction(TextInputAction.send);
+        }
+        await tester.pump();
+        expect(sendCount, 1);
+
+        sendCompleter.complete();
+        await tester.pump();
+        await tester.pump();
+
+        expect(_focusNode(tester, field).hasFocus, isTrue);
+        await tester.pump(const Duration(milliseconds: 150));
+      },
+    );
+  }
+}
+
+enum _SubmitMethod { button, keyboard }
+
+FocusNode _focusNode(WidgetTester tester, Finder field) => tester
+    .widget<EditableText>(
+      find.descendant(of: field, matching: find.byType(EditableText)),
+    )
+    .focusNode;
+
+class _ChatInputHarness extends StatefulWidget {
+  const _ChatInputHarness({required this.onSend});
+
+  final Future<void> Function() onSend;
+
+  @override
+  State<_ChatInputHarness> createState() => _ChatInputHarnessState();
+}
+
+class _ChatInputHarnessState extends State<_ChatInputHarness> {
+  final _controller = TextEditingController();
+  var _isLoading = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    setState(() => _isLoading = true);
+    await widget.onSend();
+    _controller.clear();
+    if (mounted) setState(() => _isLoading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextInputArea(
+      textController: _controller,
+      hasText: _controller.text.trim().isNotEmpty,
+      isLoading: _isLoading,
+      conversationType: 'synctv',
+      onSendMessage: _send,
+      onShowImagePicker: () {},
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- await chat send completion before restoring composer focus
- keep button and keyboard submission behavior consistent
- add regression coverage for both send paths

## Verification

- `flutter test` (750 tests)
- `dart analyze`
- real macOS App against the local Rust backend with two consecutive messages

Fixes synctv-org/synctv#391