### PR TITLE
release: prepare v1.1.22

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.21+20
+version: 1.1.22+21
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## Summary

- bump SyncTV App to 1.1.22+21
- release from latest upstream main including the Android launcher icon fix
- pair with SyncTV Server v1.0.2 protocol contracts

## Verification

- `dart format --output=none --set-exit-if-changed lib test tool`
- `dart analyze --fatal-infos`
- `flutter test test/tool/app_icon_assets_test.dart test/data/synctv_api/protobuf_synctv_test.dart`