### PR TITLE
chore(deps): migrate web auth plugin to built-in Kotlin

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,18 +321,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_web_auth_2
-      sha256: "8f9303471dcd96670878c9b7c0c4e14c37595b2add67465f6a868f17a5872dfc"
+      sha256: a76acb2eda3099f547b45e6c290d0fa21deafe72d9261e9a105b5d759f8a80ff
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "6.0.0-alpha.7"
   flutter_web_auth_2_platform_interface:
     dependency: transitive
     description:
       name: flutter_web_auth_2_platform_interface
-      sha256: ba0fbba55bffb47242025f96852ad1ffba34bc451568f56ef36e613612baffab
+      sha256: "6d3f35c0435225f31c9734be69cb5ce6f4fad194d6648b00c10eaf5a844837c9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0-alpha.2"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1394,10 +1394,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_to_front
-      sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"
+      sha256: fe896421a872360fe38b40ab3371f94fd7ae24bd0413a0b9bbfd14e27d8cba5a
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4"
+    version: "1.0.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,8 @@ dependencies:
   media_kit_libs_android_video: ^1.3.8
   media_kit_libs_ios_video: ^1.1.4
   media_kit_libs_windows_video: ^1.0.11
-  flutter_web_auth_2: ^5.0.3
+  # 6.0.0-alpha.7+ adopts AGP 9 Built-in Kotlin.
+  flutter_web_auth_2: ^6.0.0-alpha.7
   url_launcher: ^6.3.2
   flutter_markdown_plus: ^1.0.12
   passkeys: ^2.21.1
@@ -66,7 +67,7 @@ dependencies:
   desktop_webview_window: ^0.3.0
   media_kit_libs_macos_video: ^1.1.4
   window_manager: ^0.5.2
-  window_to_front: ^0.0.4
+  window_to_front: ^1.0.0
   forui: ^0.25.0
   flex_color_scheme: ^8.4.0
   responsive_framework: ^1.5.1


### PR DESCRIPTION
## Summary
- upgrade `flutter_web_auth_2` to `6.0.0-alpha.7`, the upstream release that adopts AGP 9 Built-in Kotlin
- upgrade `window_to_front` to `1.0.0` to satisfy the new plugin constraint while preserving `WindowToFront.activate()`
- refresh the lockfile only for the affected packages

## CI warning impact
The Android KGP warning list drops `flutter_web_auth_2`; the remaining warnings are from current upstream packages:
- `flutter_webrtc` still applies KGP and uses deprecated Android Camera/Fragment APIs
- `passkeys_android`, `passkeys_doctor`, and `ua_client_hints` still apply KGP; `passkeys_doctor` still uses deprecated signature APIs
- `video_player_avfoundation` still declares deprecated `AVKeyValueStatus`
- `media_kit_video` and related packages still lack Swift Package Manager support

No local overrides or copied third-party source were added.

## Validation
- `dart analyze --fatal-infos`
- `flutter test` (761 tests passed)
- `packages/passkeys_darwin`: `flutter test` (6 tests passed)
- Android release APK build passed
- macOS release build passed
- iOS unsigned release build passed
