### PR TITLE
fix: preserve room password policy and chat read state

### DIFF
--- a/lib/contracts/proto_mapping.dart
+++ b/lib/contracts/proto_mapping.dart
@@ -8,6 +8,8 @@ import 'package:synctv_app/src/generated/proto/admin.pb.dart' as admin;
 import 'package:synctv_app/src/generated/proto/client.pb.dart' as client;
 import 'package:synctv_app/src/generated/proto/client.pbenum.dart'
     as client_enum;
+import 'package:synctv_app/src/generated/proto/common.pbenum.dart'
+    as common_enum;
 import 'package:synctv_app/src/generated/proto/oauth2.pbenum.dart'
     as oauth2_enum;
 import 'package:synctv_app/src/generated/proto/passkey.pb.dart' as passkey;
@@ -751,6 +753,16 @@ Map<String, dynamic> runtimeSettingsSectionToJson(
           ? _runtimeSettingsWithDefaults(settings.roomCreation, {
               'enabled': settings.roomCreation.enabled,
               'approvalRequired': settings.roomCreation.approvalRequired,
+              'passwordPolicy':
+                  settings.roomCreation.passwordPolicy ==
+                      common_enum
+                          .RoomPasswordPolicy
+                          .ROOM_PASSWORD_POLICY_UNSPECIFIED
+                  ? common_enum
+                        .RoomPasswordPolicy
+                        .ROOM_PASSWORD_POLICY_OPTIONAL
+                        .name
+                  : settings.roomCreation.passwordPolicy.name,
               'maxRoomsPerUser': settings.roomCreation.maxRoomsPerUser
                   .toString(),
             })

--- a/lib/features/admin/presentation/tabs/runtime_settings_tab.dart
+++ b/lib/features/admin/presentation/tabs/runtime_settings_tab.dart
@@ -583,17 +583,17 @@ class _SettingChoice {
 
 List<_SettingChoice> _roomPasswordChoices(AppLocalizations l10n) => [
   _SettingChoice(
-    'optional',
+    'ROOM_PASSWORD_POLICY_OPTIONAL',
     l10n.optional,
     l10n.roomPasswordOptionalDescription,
   ),
   _SettingChoice(
-    'required',
+    'ROOM_PASSWORD_POLICY_REQUIRED',
     l10n.required,
     l10n.roomPasswordRequiredDescription,
   ),
   _SettingChoice(
-    'forbidden',
+    'ROOM_PASSWORD_POLICY_FORBIDDEN',
     l10n.disabled,
     l10n.roomPasswordDisabledDescription,
   ),

--- a/lib/features/room/application/chat_read_state_updater.dart
+++ b/lib/features/room/application/chat_read_state_updater.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+/// Coalesces visible-message read cursor updates while preserving the newest
+/// cursor received during an in-flight request.
+final class ChatReadStateUpdater {
+  ChatReadStateUpdater({required this.markRead});
+
+  final Future<void> Function(String messageId) markRead;
+
+  String? _pendingMessageId;
+  bool _inFlight = false;
+  bool _disposed = false;
+
+  void markVisible(String messageId) {
+    if (_disposed || messageId.isEmpty) return;
+    _pendingMessageId = messageId;
+    if (!_inFlight) unawaited(_flush());
+  }
+
+  void dispose() {
+    _disposed = true;
+    _pendingMessageId = null;
+  }
+
+  Future<void> _flush() async {
+    if (_inFlight || _disposed) return;
+    _inFlight = true;
+    try {
+      while (!_disposed) {
+        final messageId = _pendingMessageId;
+        _pendingMessageId = null;
+        if (messageId == null) return;
+        try {
+          await markRead(messageId);
+        } catch (_) {
+          // The next visible message retries the cursor update.
+        }
+      }
+    } finally {
+      _inFlight = false;
+      if (!_disposed && _pendingMessageId != null) {
+        unawaited(_flush());
+      }
+    }
+  }
+}

--- a/lib/features/room/presentation/create_room_dialog.dart
+++ b/lib/features/room/presentation/create_room_dialog.dart
@@ -388,65 +388,9 @@ class _CreateRoomDialogBodyState extends State<_CreateRoomDialogBody> {
                       ),
                       const SizedBox(height: 18),
                       _buildTaxonomySection(theme),
-                      const SizedBox(height: 18),
-                      Text(
-                        l10n.accessMethod,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      _AccessModeSelector(
-                        value: _accessMode,
-                        passwordRequired: _passwordRequired,
-                        passwordForbidden: _passwordForbidden,
-                        enabled:
-                            !_creating &&
-                            !_creationDisabled &&
-                            _settingsError == null,
-                        onChanged: (value) {
-                          setState(() {
-                            _accessMode = value;
-                            if (value == _RoomAccessMode.public) {
-                              _passwordController.clear();
-                            }
-                          });
-                        },
-                      ),
                       if (!_passwordForbidden) ...[
-                        AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 180),
-                          child: _needPassword
-                              ? Padding(
-                                  key: const ValueKey('password'),
-                                  padding: const EdgeInsets.only(top: 12),
-                                  child: AppTextField(
-                                    controller: _passwordController,
-                                    label: l10n.roomPassword,
-                                    hintText: _passwordRequired
-                                        ? l10n.serverRequiresPassword
-                                        : l10n.membersEnterPassword,
-                                    errorText:
-                                        _submitted && _passwordError.isNotEmpty
-                                        ? _passwordError
-                                        : null,
-                                    prefixIcon: Icons.lock_outline_rounded,
-                                    enabled:
-                                        !_creating &&
-                                        !_creationDisabled &&
-                                        _settingsError == null,
-                                    obscureText: true,
-                                    onChanged: (value) {
-                                      if (!_submitted) return;
-                                      setState(
-                                        () => _passwordError =
-                                            _validatePassword(value) ?? '',
-                                      );
-                                    },
-                                  ),
-                                )
-                              : const SizedBox.shrink(),
-                        ),
+                        const SizedBox(height: 18),
+                        _buildAccessSection(theme),
                       ],
                     ],
                   ),
@@ -500,6 +444,69 @@ class _CreateRoomDialogBodyState extends State<_CreateRoomDialogBody> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildAccessSection(ThemeData theme) {
+    if (_passwordRequired) return _buildPasswordField();
+
+    final l10n = context.l10n;
+    final enabled = !_creating && !_creationDisabled && _settingsError == null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.accessMethod,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 12),
+        _AccessModeSelector(
+          value: _accessMode,
+          enabled: enabled,
+          onChanged: (value) {
+            setState(() {
+              _accessMode = value;
+              if (value == _RoomAccessMode.public) {
+                _passwordController.clear();
+              }
+            });
+          },
+        ),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 180),
+          child: _needPassword
+              ? Padding(
+                  key: const ValueKey('password'),
+                  padding: const EdgeInsets.only(top: 12),
+                  child: _buildPasswordField(),
+                )
+              : const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPasswordField() {
+    final l10n = context.l10n;
+    return AppTextField(
+      key: const ValueKey('create-room-password'),
+      controller: _passwordController,
+      label: l10n.roomPassword,
+      hintText: _passwordRequired
+          ? l10n.serverRequiresPassword
+          : l10n.membersEnterPassword,
+      errorText: _submitted && _passwordError.isNotEmpty
+          ? _passwordError
+          : null,
+      prefixIcon: Icons.lock_outline_rounded,
+      enabled: !_creating && !_creationDisabled && _settingsError == null,
+      obscureText: true,
+      onChanged: (value) {
+        if (!_submitted) return;
+        setState(() => _passwordError = _validatePassword(value) ?? '');
+      },
     );
   }
 
@@ -710,44 +717,34 @@ class _CreateRoomHeader extends StatelessWidget {
 
 class _AccessModeSelector extends StatelessWidget {
   final _RoomAccessMode value;
-  final bool passwordRequired;
-  final bool passwordForbidden;
   final bool enabled;
   final ValueChanged<_RoomAccessMode> onChanged;
 
   const _AccessModeSelector({
     required this.value,
-    required this.passwordRequired,
-    required this.passwordForbidden,
     required this.enabled,
     required this.onChanged,
   });
 
   @override
   Widget build(BuildContext context) {
-    final canUsePublic = enabled && !passwordRequired;
-    final canUsePassword = enabled && !passwordForbidden;
     return LayoutBuilder(
       builder: (context, constraints) {
         final stacked = constraints.maxWidth < 520;
         final publicCard = _AccessModeCard(
           selected: value == _RoomAccessMode.public,
-          enabled: canUsePublic,
+          enabled: enabled,
           icon: Icons.public_rounded,
           title: context.l10n.publicRoom,
-          subtitle: passwordRequired
-              ? context.l10n.serverRequiresPassword
-              : context.l10n.publicRoomJoinHint,
+          subtitle: context.l10n.publicRoomJoinHint,
           onTap: () => onChanged(_RoomAccessMode.public),
         );
         final passwordCard = _AccessModeCard(
           selected: value == _RoomAccessMode.password,
-          enabled: canUsePassword,
+          enabled: enabled,
           icon: Icons.lock_outline_rounded,
           title: context.l10n.passwordRoom,
-          subtitle: passwordForbidden
-              ? context.l10n.serverForbidsPassword
-              : context.l10n.passwordRoomJoinHint,
+          subtitle: context.l10n.passwordRoomJoinHint,
           onTap: () => onChanged(_RoomAccessMode.password),
         );
 

--- a/lib/features/room/presentation/room_screen.dart
+++ b/lib/features/room/presentation/room_screen.dart
@@ -34,6 +34,7 @@ import 'package:synctv_app/features/room/application/realtime_event_log_preferen
 import 'package:synctv_app/core/network/resource_url_resolver.dart';
 import 'package:synctv_app/core/presentation/dependency_scope.dart';
 import 'package:synctv_app/features/room/application/room_chat_gateway.dart';
+import 'package:synctv_app/features/room/application/chat_read_state_updater.dart';
 import 'package:synctv_app/features/room/application/room_playback_gateway.dart';
 import 'package:synctv_app/features/room/application/room_playback_controller.dart';
 import 'package:synctv_app/features/room/application/playback_mode_preferences_controller.dart';
@@ -290,6 +291,7 @@ class _RoomScreenState extends State<RoomScreen>
   static const _endedLiveStreamDrainTimeout = Duration(seconds: 120);
 
   late final RoomChatGateway _chatGateway;
+  late final ChatReadStateUpdater _chatReadStateUpdater;
   late final RoomPlaybackGateway _playbackGateway;
   late final PlaybackModePreferencesController _playbackModePreferences;
   late final RoomSessionGateway _sessionGateway;
@@ -560,6 +562,10 @@ class _RoomScreenState extends State<RoomScreen>
     super.initState();
     _mediaSearchController = TextEditingController();
     _chatGateway = DependencyScope.read<RoomChatGateway>(context);
+    _chatReadStateUpdater = ChatReadStateUpdater(
+      markRead: (messageId) =>
+          _chatGateway.markRead(widget.room.roomId, messageId),
+    );
     _playbackGateway = DependencyScope.read<RoomPlaybackGateway>(context);
     _playbackController = RoomPlaybackController();
     _playbackModePreferences =
@@ -1110,6 +1116,9 @@ class _RoomScreenState extends State<RoomScreen>
           .where((entry) => !entry.isDeleted)
           .toList()
           .reversed;
+      if (_canViewChatHistory && page.messages.isNotEmpty) {
+        _chatReadStateUpdater.markVisible(page.messages.first.id);
+      }
       if (mounted) {
         setState(() {
           _messages.prependUnique(history, maxEntries: 100);
@@ -1474,6 +1483,9 @@ class _RoomScreenState extends State<RoomScreen>
         });
         if (shouldAutoScroll) {
           _scrollToBottom();
+          if (message.isChatCreated && _canViewChatHistory) {
+            _chatReadStateUpdater.markVisible(chatEntry.id);
+          }
         } else if (!_showChatScrollToBottom) {
           setState(() => _showChatScrollToBottom = true);
         }
@@ -3306,6 +3318,7 @@ class _RoomScreenState extends State<RoomScreen>
   @override
   void dispose() {
     _isDisposing = true;
+    _chatReadStateUpdater.dispose();
     _realtimeLogPreferences.maxEntries.removeListener(
       _handleRealtimeLogMaxEntriesChanged,
     );
@@ -3377,6 +3390,9 @@ class _RoomScreenState extends State<RoomScreen>
     final show = !_isChatNearBottom();
     if (show != _showChatScrollToBottom && mounted) {
       setState(() => _showChatScrollToBottom = show);
+    }
+    if (!show && _canViewChatHistory && _messages.isNotEmpty) {
+      _chatReadStateUpdater.markVisible(_messages.last.id);
     }
   }
 

--- a/test/contracts/proto_mapping_test.dart
+++ b/test/contracts/proto_mapping_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:synctv_app/contracts/proto_mapping.dart';
 import 'package:synctv_app/src/generated/proto/admin.pb.dart' as admin;
+import 'package:synctv_app/src/generated/proto/common.pbenum.dart' as common;
 import 'package:synctv_app/src/generated/proto/oauth2.pbenum.dart';
 
 void main() {
@@ -67,7 +68,16 @@ void main() {
     );
     expect(
       runtimeSettingsSectionToJson(settings, 'roomCreation').keys,
-      containsAll(<String>['enabled', 'approvalRequired']),
+      containsAll(<String>[
+        'enabled',
+        'approvalRequired',
+        'passwordPolicy',
+        'maxRoomsPerUser',
+      ]),
+    );
+    expect(
+      runtimeSettingsSectionToJson(settings, 'roomCreation')['passwordPolicy'],
+      common.RoomPasswordPolicy.ROOM_PASSWORD_POLICY_OPTIONAL.name,
     );
     expect(
       runtimeSettingsSectionToJson(settings, 'email').keys,

--- a/test/data/synctv_api/protobuf_synctv_test.dart
+++ b/test/data/synctv_api/protobuf_synctv_test.dart
@@ -6972,6 +6972,11 @@ void main() {
         false,
       );
       await SyncTvService.runtimeUpdateSettingInSection(
+        'roomCreation',
+        'passwordPolicy',
+        'ROOM_PASSWORD_POLICY_FORBIDDEN',
+      );
+      await SyncTvService.runtimeUpdateSettingInSection(
         'cors',
         'allowedOrigins',
         ['https://app.example.test'],
@@ -7032,6 +7037,12 @@ void main() {
           'roomCreation': {'enabled': false},
         },
         'updateMask': 'roomCreation.enabled',
+      },
+      {
+        'settings': {
+          'roomCreation': {'passwordPolicy': 3},
+        },
+        'updateMask': 'roomCreation.passwordPolicy',
       },
       {
         'settings': {

--- a/test/features/room/application/chat_read_state_updater_test.dart
+++ b/test/features/room/application/chat_read_state_updater_test.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/features/room/application/chat_read_state_updater.dart';
+
+void main() {
+  test(
+    'coalesces visible messages received during an in-flight update',
+    () async {
+      final calls = <String>[];
+      final firstCall = Completer<void>();
+      final updater = ChatReadStateUpdater(
+        markRead: (messageId) async {
+          calls.add(messageId);
+          if (messageId == 'first') await firstCall.future;
+        },
+      );
+
+      updater
+        ..markVisible('first')
+        ..markVisible('second')
+        ..markVisible('third');
+      await Future<void>.delayed(Duration.zero);
+      expect(calls, ['first']);
+
+      firstCall.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls, ['first', 'third']);
+    },
+  );
+
+  test('continues with the latest cursor after a failed update', () async {
+    final calls = <String>[];
+    final updater = ChatReadStateUpdater(
+      markRead: (messageId) async {
+        calls.add(messageId);
+        if (messageId == 'first') throw StateError('temporary failure');
+      },
+    );
+
+    updater
+      ..markVisible('first')
+      ..markVisible('second');
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(calls, ['first', 'second']);
+  });
+}

--- a/test/features/room/presentation/create_room_dialog_test.dart
+++ b/test/features/room/presentation/create_room_dialog_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/contracts/public_models.dart';
+import 'package:synctv_app/contracts/synctv_models.dart';
+import 'package:synctv_app/core/presentation/dependency_scope.dart';
+import 'package:synctv_app/features/room/application/room_creation_gateway.dart';
+import 'package:synctv_app/features/room/presentation/create_room_dialog.dart';
+import 'package:synctv_app/l10n/app_localizations.dart';
+import 'package:synctv_app/src/generated/proto/common.pbenum.dart' as common;
+
+import '../../../test_app.dart';
+
+void main() {
+  testWidgets('required password policy directly renders its password field', (
+    tester,
+  ) async {
+    await _pumpCreateRoomDialog(
+      tester,
+      common.RoomPasswordPolicy.ROOM_PASSWORD_POLICY_REQUIRED,
+    );
+
+    expect(find.text('Access method'), findsNothing);
+    expect(find.byKey(const ValueKey('create-room-password')), findsOneWidget);
+    expect(find.text('Password room'), findsNothing);
+  });
+
+  testWidgets('forbidden password policy omits the fixed access controls', (
+    tester,
+  ) async {
+    await _pumpCreateRoomDialog(
+      tester,
+      common.RoomPasswordPolicy.ROOM_PASSWORD_POLICY_FORBIDDEN,
+    );
+
+    expect(find.text('Access method'), findsNothing);
+    expect(find.byKey(const ValueKey('create-room-password')), findsNothing);
+    expect(find.text('Password room'), findsNothing);
+  });
+
+  testWidgets('optional password policy keeps the access selector', (
+    tester,
+  ) async {
+    await _pumpCreateRoomDialog(
+      tester,
+      common.RoomPasswordPolicy.ROOM_PASSWORD_POLICY_OPTIONAL,
+    );
+
+    expect(find.text('Access method'), findsOneWidget);
+    expect(find.text('Public room'), findsOneWidget);
+    expect(find.text('Password room'), findsOneWidget);
+    expect(find.byKey(const ValueKey('create-room-password')), findsNothing);
+
+    await tester.ensureVisible(find.text('Password room'));
+    await tester.tap(find.text('Password room'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('create-room-password')), findsOneWidget);
+  });
+}
+
+Future<void> _pumpCreateRoomDialog(
+  WidgetTester tester,
+  common.RoomPasswordPolicy passwordPolicy,
+) async {
+  await tester.pumpWidget(
+    DependencyScope<RoomCreationGateway>(
+      value: _FakeRoomCreationGateway(_settings(passwordPolicy)),
+      child: MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        builder: buildThemedTestApp,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => showCreateRoomDialog(
+                context: context,
+                onCreated: (_) async {},
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+}
+
+PublicSettingsInfo _settings(common.RoomPasswordPolicy passwordPolicy) =>
+    PublicSettingsInfo(
+      roomCreationEnabled: true,
+      maxRoomsPerUser: 10,
+      defaultMaxMembers: 100,
+      roomCreationApprovalRequired: false,
+      roomPasswordPolicy: passwordPolicy,
+      enablePasswordSignup: true,
+      passwordSignupNeedReview: false,
+      enableEmailSignup: true,
+      enableEmail: true,
+      enableGuest: true,
+      emailSignupNeedReview: false,
+      enableWebauthn: false,
+      webauthnRpId: '',
+      enableWebauthnSignup: false,
+      webauthnSignupNeedReview: false,
+      emailWhitelistEnabled: false,
+      emailWhitelistDomains: const [],
+      tsDisguisedAsPng: false,
+      customPublishHost: null,
+    );
+
+final class _FakeRoomCreationGateway implements RoomCreationGateway {
+  const _FakeRoomCreationGateway(this.settings);
+
+  final PublicSettingsInfo settings;
+
+  @override
+  Future<SyncTvRoom> createRoom(
+    String name, {
+    String? password,
+    String? description,
+    String categoryId = '',
+    List<String> labelIds = const [],
+  }) => Future<SyncTvRoom>.error(UnimplementedError());
+
+  @override
+  Future<PublicSettingsInfo> getPublicSettings({bool refresh = false}) async =>
+      settings;
+
+  @override
+  Future<List<RoomCategoryInfo>> listCategories({bool refresh = false}) async =>
+      const [];
+
+  @override
+  Future<List<RoomLabelInfo>> listLabels({bool refresh = false}) async =>
+      const [];
+}


### PR DESCRIPTION
## Changes
- Serialize room password policies with generated protobuf enum values.
- Normalize an unspecified policy to the optional policy expected by runtime settings.
- Render fixed password policies directly in the room form: required mode shows the password field, forbidden mode uses public access, and optional mode retains the selector.
- Coalesce visible chat-message read cursor updates and retain the newest cursor during network requests.

## Automated tests
- flutter test test/features/room/presentation/create_room_dialog_test.dart test/contracts/proto_mapping_test.dart test/data/synctv_api/protobuf_synctv_test.dart
- dart analyze lib/features/room/presentation/create_room_dialog.dart test/features/room/presentation/create_room_dialog_test.dart
- dart format --set-exit-if-changed <changed Dart files>

## Manual verification
- Ran the current macOS debug client against the local SyncTV server.
- Set the room-password policy through the administrator UI and observed public setting values `2` (required), `3` (forbidden), and `1` (restored optional).
- Required mode directly rendered the password field without an access-method heading or mode cards.
- Forbidden mode created a public room without a password control.
- Optional mode was restored after verification.