### PR TITLE
fix: retry playback synchronization after lag

### DIFF
--- a/lib/features/room/domain/playback_sync_target.dart
+++ b/lib/features/room/domain/playback_sync_target.dart
@@ -31,3 +31,14 @@ PlaybackSyncTarget resolvePlaybackSyncTarget({
   }
   return PlaybackSyncTarget(positionSeconds: computedTime);
 }
+
+bool shouldAutoSeekToPlaybackSyncTarget({
+  required double currentPositionSeconds,
+  required PlaybackSyncTarget target,
+  required double driftThresholdSeconds,
+  required bool freeModeEnabled,
+}) {
+  if (freeModeEnabled) return false;
+  return (currentPositionSeconds - target.positionSeconds).abs() >
+      driftThresholdSeconds;
+}

--- a/lib/features/room/presentation/room_screen.dart
+++ b/lib/features/room/presentation/room_screen.dart
@@ -919,6 +919,7 @@ class _RoomScreenState extends State<RoomScreen>
     _samplePlaybackDiagnostics();
     _diagnosticsTimer = Timer.periodic(const Duration(seconds: 2), (_) {
       if (!mounted) return;
+      _retryAutomaticPlaybackSync();
       setState(_samplePlaybackDiagnostics);
     });
   }
@@ -2022,8 +2023,14 @@ class _RoomScreenState extends State<RoomScreen>
         final currentPos = controller.value.position.inMilliseconds / 1000.0;
         final positionDrift = (currentPos - target.positionSeconds).abs();
         final shouldAutoSeek =
-            !_playbackModeConfig.freeModeEnabled &&
-            positionDrift > _playbackModeConfig.autoSeekDriftThresholdSeconds;
+            target.isAtEnd ||
+            shouldAutoSeekToPlaybackSyncTarget(
+              currentPositionSeconds: currentPos,
+              target: target,
+              driftThresholdSeconds:
+                  _playbackModeConfig.autoSeekDriftThresholdSeconds,
+              freeModeEnabled: _playbackModeConfig.freeModeEnabled,
+            );
         final shouldManualSeek =
             forceSeek &&
             positionDrift >=
@@ -2065,6 +2072,32 @@ class _RoomScreenState extends State<RoomScreen>
       duration: controller.value.duration,
       now: SyncedClock.now(),
     );
+  }
+
+  void _retryAutomaticPlaybackSync() {
+    if (_isSyncing || _playbackModeConfig.freeModeEnabled) return;
+
+    final status = _currentStatus;
+    final controller = _videoPlayerController;
+    if (status?.entry?.live != false ||
+        controller == null ||
+        !controller.value.isInitialized) {
+      return;
+    }
+
+    final target = _playbackSyncTarget(status!, controller);
+    final currentPositionSeconds =
+        controller.value.position.inMilliseconds / 1000.0;
+    if (!shouldAutoSeekToPlaybackSyncTarget(
+      currentPositionSeconds: currentPositionSeconds,
+      target: target,
+      driftThresholdSeconds: _playbackModeConfig.autoSeekDriftThresholdSeconds,
+      freeModeEnabled: _playbackModeConfig.freeModeEnabled,
+    )) {
+      return;
+    }
+
+    unawaited(_performSync(status));
   }
 
   double? _playbackDeviationSeconds() {

--- a/test/features/room/domain/playback_mode_config_test.dart
+++ b/test/features/room/domain/playback_mode_config_test.dart
@@ -268,6 +268,40 @@ void main() {
   });
 
   test(
+    'non-free mode retries automatic sync after delayed playback falls behind',
+    () {
+      final target = resolvePlaybackSyncTarget(
+        status: SyncTvPlaybackStatus(
+          isPlaying: true,
+          currentTime: 10,
+          generatedAtMillis: 1_000,
+        ),
+        duration: const Duration(seconds: 30),
+        now: DateTime.fromMillisecondsSinceEpoch(4_000),
+      );
+
+      expect(
+        shouldAutoSeekToPlaybackSyncTarget(
+          currentPositionSeconds: 10,
+          target: target,
+          driftThresholdSeconds: 1.2,
+          freeModeEnabled: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldAutoSeekToPlaybackSyncTarget(
+          currentPositionSeconds: 10,
+          target: target,
+          driftThresholdSeconds: 1.2,
+          freeModeEnabled: true,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test(
     'sync target preserves derived playback position without known duration',
     () {
       final target = resolvePlaybackSyncTarget(


### PR DESCRIPTION
## Summary
- retry non-free playback synchronization when the local player falls behind a time-derived room target
- preserve free mode, live playback, in-flight synchronization, and end-of-media behavior
- add a regression test for delayed playback without a newer realtime status

## Verification
- flutter analyze
- flutter test