### PR TITLE
chore(deps): update frontend dependencies

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import audio_session
 import desktop_webview_window
 import device_info_plus
-import file_picker
+import file_picker_darwin
 import flutter_web_auth_2
 import flutter_webrtc
 import media_kit_libs_macos_video
@@ -18,7 +18,6 @@ import passkeys_darwin
 import screen_brightness_macos
 import screen_retriever_macos
 import shared_preferences_foundation
-import ua_client_hints
 import url_launcher_macos
 import video_player_avfoundation
 import volume_controller
@@ -41,7 +40,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  UAClientHintsPlugin.register(with: registry.registrar(forPlugin: "UAClientHintsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -4,14 +4,11 @@ PODS:
     - FlutterMacOS
   - media_kit_video (0.0.1):
     - FlutterMacOS
-  - ua_client_hints (1.7.0):
-    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
-  - ua_client_hints (from `Flutter/ephemeral/.symlinks/plugins/ua_client_hints/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -20,14 +17,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos
   media_kit_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
-  ua_client_hints:
-    :path: Flutter/ephemeral/.symlinks/plugins/ua_client_hints/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
   media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758
-  ua_client_hints: bb84da85d9d5d605d40598b3c1ae3bfd2598e201
 
 PODFILE CHECKSUM: 686352462aa35bc3742cd0ba5f5f22982a80a20d
 

--- a/packages/passkeys_darwin/CHANGELOG.md
+++ b/packages/passkeys_darwin/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Handle registration responses with a nil raw attestation object.
 - Document the upstream baseline and the conditions for removing this fork.
 
+## 0.4.3+3
+
+- **FIX**(passkeys_darwin): compile out Signal API on Xcode older than 26.2
+  ([#289](https://github.com/corbado/flutter-passkeys/issues/289)).
+
 ## 0.4.2+2
 
  - **FIX**(passkeys_darwin): map no-credentials-available regardless of device locale ([#271](https://github.com/corbado/flutter-passkeys/issues/271)). ([7414c54a](https://github.com/corbado/flutter-passkeys/commit/7414c54a24ddde979bc2d64d19b28a52065fc8ca))

--- a/packages/passkeys_darwin/README.md
+++ b/packages/passkeys_darwin/README.md
@@ -5,9 +5,9 @@ pending upstream in [corbado/flutter-passkeys][upstream].
 
 ## Fork rationale
 
-The fork is based on the published `passkeys_darwin 0.4.2+2` package. The
-upstream `main` branch was last checked on 2026-07-25 at
-[`fffb633005ed7581d715cec89a51149c635f05da`][checked-commit]. It still had the
+The fork is based on the published `passkeys_darwin 0.4.3+3` package. The
+upstream `main` branch was last checked on 2026-08-18 at
+[`a1fdabef92a8bd6d4c59f0c9bbf41df295a75f10`][checked-commit]. It still had the
 following defects:
 
 1. Registration and authentication preserve WebAuthn `userVerification` in
@@ -45,7 +45,7 @@ Delete `packages/passkeys_darwin` and the root dependency override together
 once those conditions are met.
 
 [upstream]: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys_darwin
-[checked-commit]: https://github.com/corbado/flutter-passkeys/commit/fffb633005ed7581d715cec89a51149c635f05da
+[checked-commit]: https://github.com/corbado/flutter-passkeys/commit/a1fdabef92a8bd6d4c59f0c9bbf41df295a75f10
 
 ## Usage
 

--- a/packages/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
+++ b/packages/passkeys_darwin/darwin/passkeys_darwin/Sources/passkeys_darwin/PasskeysPlugin.swift
@@ -252,6 +252,9 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
             return
         }
 
+        // ASCredentialDataManager only exists in the 26.2 SDK (Xcode 26.2,
+        // Swift 6.2.3), so it must also be compiled out on older toolchains.
+        #if compiler(>=6.2.3)
         if #available(iOS 26.2, macOS 26.2, *) {
             Task {
                 do {
@@ -266,11 +269,13 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
                     }
                 }
             }
-        } else {
-            // The Signal API is unavailable on this OS version; the hint is
-            // best-effort so treat it as a no-op.
-            completion(.success(()))
+            return
         }
+        #endif
+
+        // The Signal API is unavailable on this OS version or SDK; the hint is
+        // best-effort so treat it as a no-op.
+        completion(.success(()))
     }
 
     func signalAllAcceptedCredentials(relyingPartyId: String, userId: String, allAcceptedCredentialIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
@@ -290,6 +295,7 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
             credentialIDs.append(credentialData)
         }
 
+        #if compiler(>=6.2.3)
         if #available(iOS 26.2, macOS 26.2, *) {
             Task {
                 do {
@@ -305,11 +311,13 @@ public class PasskeysPlugin: NSObject, FlutterPlugin, PasskeysApi {
                     }
                 }
             }
-        } else {
-            // The Signal API is unavailable on this OS version; the hint is
-            // best-effort so treat it as a no-op.
-            completion(.success(()))
+            return
         }
+        #endif
+
+        // The Signal API is unavailable on this OS version or SDK; the hint is
+        // best-effort so treat it as a no-op.
+        completion(.success(()))
     }
 
     private func parseCredentials(credentials: [CredentialType]) -> [ASAuthorizationPlatformPublicKeyCredentialDescriptor] {

--- a/packages/passkeys_darwin/pubspec.yaml
+++ b/packages/passkeys_darwin/pubspec.yaml
@@ -3,7 +3,7 @@ description: Shared Darwin implementation (iOS & macOS) of the Corbado passkeys 
 publish_to: none
 homepage: https://docs.corbado.com/overview/welcome
 repository: https://github.com/corbado/flutter-passkeys/tree/main/packages/passkeys/passkeys_darwin
-version: 0.4.2+2
+version: 0.4.3+3
 
 environment:
   sdk: ">=3.9.0 <4.0.0"
@@ -31,6 +31,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pigeon: ^27.3.0
+  pigeon: ^27.3.1
   plugin_platform_interface: ^2.0.0
   very_good_analysis: ^10.3.0

--- a/packages/synctv_opaque/pubspec.yaml
+++ b/packages/synctv_opaque/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   code_assets: ^1.2.1
   ffi: ^2.2.0
+  # hooks 2.1+ requires record_use 1.x, which requires meta ^1.19.0.
+  # Flutter 3.44.8 pins meta to 1.18.0, so keep the compatible release.
   hooks: ^2.0.2
 
 dev_dependencies:

--- a/packages/synctv_video_player_media_kit/lib/src/cancellable_media_kit_video_player.dart
+++ b/packages/synctv_video_player_media_kit/lib/src/cancellable_media_kit_video_player.dart
@@ -9,7 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
-import 'package:video_player/video_player.dart';
+import 'package:video_player/video_player.dart' hide VideoTrack;
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
     hide VideoTrack;
 

--- a/packages/synctv_video_player_media_kit/pubspec.yaml
+++ b/packages/synctv_video_player_media_kit/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   media_kit: ^1.2.6
   media_kit_video: ^2.0.1
   http: ^1.6.0
-  video_player: ^2.12.0
+  video_player: ^2.14.0
   video_player_platform_interface: ^6.6.0
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
+  android_file_picker:
+    dependency: transitive
+    description:
+      name: android_file_picker
+      sha256: "665a5a57dfca27f91a715d300e4852a784f9f98e503dcff281bec9afb55767be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   archive:
     dependency: transitive
     description:
@@ -221,10 +229,42 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: fdc6a37f715d19f35b131decf1ce39242eeed5ddae18c0818c3eccb731ab76be
+      sha256: afbaa8015d9efabd224f41084ed9fdeddfa65389ebd7cd3a9eb1476aca66b46d
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0-beta.7"
+    version: "12.0.0"
+  file_picker_darwin:
+    dependency: transitive
+    description:
+      name: file_picker_darwin
+      sha256: "5d87d156c1d63920447a662b7117d3498c67e3444a44d2cb01ed955d6efa62ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  file_picker_linux:
+    dependency: transitive
+    description:
+      name: file_picker_linux
+      sha256: "93d3f62f97c657053e7b184fe0f5e22347d85067c053640a30b1ac8ad7844e3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  file_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: file_picker_platform_interface
+      sha256: "9e7a7e01e179929241f0afeb2c8c69ac95e29e17c0abea36ed193881c6bef90c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  file_picker_web:
+    dependency: transitive
+    description:
+      name: file_picker_web
+      sha256: f1af38b3c91fafe0ca97f659b5c6818a057473ef09bb8b722f9f3f5364aa7eed
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   fixnum:
     dependency: "direct main"
     description:
@@ -296,14 +336,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.12"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.35"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -616,25 +648,25 @@ packages:
     dependency: "direct main"
     description:
       name: passkeys
-      sha256: c403ac1af65d94f508d4ae4de7c5af0179201e1de466f8f182a015fdaece8172
+      sha256: "1596fa3940c458fcd0062ce222d7fec69d9b70187a4b9e67d585e0386f73e18c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.0"
+    version: "2.22.3"
   passkeys_android:
     dependency: transitive
     description:
       name: passkeys_android
-      sha256: dc3717c5541d464bf2271ce4427b34f88661a73893673616e8fddc126902045a
+      sha256: eac3af9fea5d56c7091c07bde29fe5a11269de33d9cb856e03975773aab485c4
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   passkeys_darwin:
     dependency: "direct overridden"
     description:
       path: "packages/passkeys_darwin"
       relative: true
     source: path
-    version: "0.4.2+2"
+    version: "0.4.3+3"
   passkeys_doctor:
     dependency: transitive
     description:
@@ -1044,10 +1076,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
+      sha256: "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1+1"
+    version: "3.4.1+2"
   synctv_opaque:
     dependency: "direct main"
     description:
@@ -1086,14 +1118,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  ua_client_hints:
-    dependency: transitive
-    description:
-      name: ua_client_hints
-      sha256: e6e302bb7c21d6a90023db61e0ec413f0810ce341bb7e2ab447ff5d61ec3d87e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.7.0"
   universal_platform:
     dependency: transitive
     description:
@@ -1218,10 +1242,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
+      sha256: "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   video_player_android:
     dependency: transitive
     description:
@@ -1322,10 +1346,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
+      sha256: b98656fa4461f8cc05c48a778b4d4883e60ec63e1778348f363f9bb9a477745d
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.14.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1346,10 +1370,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   win32_registry:
     dependency: transitive
     description:
@@ -1374,6 +1398,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  windows_file_picker:
+    dependency: transitive
+    description:
+      name: windows_file_picker
+      sha256: "72cf23466e146f2c0f19e1d78be97ff6409dc15b0c090f8eb284f94f4a33de26"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,14 +35,13 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
 
-  video_player: ^2.12.0
+  video_player: ^2.14.0
   protobuf: ^6.0.0
   fixnum: ^1.1.1
   http: ^1.6.0
   crypto: ^3.0.6
   xml: ^7.0.1
-  # 12.0.0-beta.3+ contains the AGP 9 Built-in Kotlin compatibility fix.
-  file_picker: ^12.0.0-beta.7
+  file_picker: ^12.0.0
   shared_preferences: ^2.5.5
   screen_brightness: ^2.1.11
   volume_controller: ^3.6.0
@@ -59,7 +58,7 @@ dependencies:
   flutter_web_auth_2: ^6.0.0-alpha.7
   url_launcher: ^6.3.2
   flutter_markdown_plus: ^1.0.12
-  passkeys: ^2.21.1
+  passkeys: ^2.22.3
   synctv_opaque:
     path: packages/synctv_opaque
   qr_flutter: ^4.1.0


### PR DESCRIPTION
## Summary

- upgrade file_picker to stable 12.0.0, passkeys to 2.22.3, video_player to 2.14.0, and compatible transitive dependencies
- rebase the local passkeys_darwin fork on 0.4.3+3 while preserving SyncTV fixes and adding the upstream old-Xcode Signal API guard
- keep Native Assets hooks compatible with Flutter 3.44.8 and resolve the new video_player/media_kit VideoTrack name collision

## Validation

- `fvm dart analyze --fatal-infos` for the app and all three local packages
- `fvm flutter test` (822 tests)
- local package tests for passkeys_darwin, synctv_opaque, and synctv_video_player_media_kit
- `fvm flutter build macos --debug`
- `fvm flutter pub get --enforce-lockfile`

## Notes

- hooks 2.1+ remains blocked because Flutter 3.44.8 pins meta 1.18.0 while record_use 1.x requires meta 1.19.0
- the Android debug build requires an Android NDK toolchain that is unavailable in the local validation environment