### PR TITLE
fix(room): reflect member-owned resource lifecycle

### DIFF
--- a/lib/contracts/synctv_models.dart
+++ b/lib/contracts/synctv_models.dart
@@ -598,6 +598,41 @@ class RoomMediaEntry {
 
   bool get isProviderDynamicEntry => isDynamicPlaylist || isProviderDynamicItem;
 
+  bool get isAvailable =>
+      availability !=
+      client.ResourceAvailability.RESOURCE_AVAILABILITY_CREATOR_INACTIVE;
+
+  client_enum.PlaylistBrowseAccessMode get effectiveBrowseAccessMode {
+    if (browseAccessMode !=
+        client_enum
+            .PlaylistBrowseAccessMode
+            .PLAYLIST_BROWSE_ACCESS_MODE_DEFAULT) {
+      return browseAccessMode;
+    }
+    return isDynamicPlaylist
+        ? client_enum
+              .PlaylistBrowseAccessMode
+              .PLAYLIST_BROWSE_ACCESS_MODE_CREATOR_ONLY
+        : client_enum
+              .PlaylistBrowseAccessMode
+              .PLAYLIST_BROWSE_ACCESS_MODE_ROOM_MEMBERS;
+  }
+
+  bool canBrowsePlaylistFor(String viewerId) {
+    if (!isPlaylist || !isAvailable || viewerId.isEmpty) return false;
+    return switch (effectiveBrowseAccessMode) {
+      client_enum
+          .PlaylistBrowseAccessMode
+          .PLAYLIST_BROWSE_ACCESS_MODE_ROOM_MEMBERS =>
+        true,
+      client_enum
+          .PlaylistBrowseAccessMode
+          .PLAYLIST_BROWSE_ACCESS_MODE_CREATOR_ONLY =>
+        creator.isNotEmpty && creator == viewerId,
+      _ => false,
+    };
+  }
+
   bool get hasPlaybackTarget =>
       (subPath ?? '').isNotEmpty && (parentId ?? '').startsWith('pl_');
 

--- a/lib/features/room/presentation/models/playlist_selection_policy.dart
+++ b/lib/features/room/presentation/models/playlist_selection_policy.dart
@@ -7,6 +7,17 @@ final class PlaylistSelectionPolicy {
 
   static bool isSelectable(RoomMediaEntry entry) => entry.id.trim().isNotEmpty;
 
+  static bool canActivate({
+    required RoomMediaEntry entry,
+    required String viewerId,
+    required bool canControlPlayback,
+  }) {
+    if (!entry.isAvailable) return false;
+    return entry.isPlaylist
+        ? entry.canBrowsePlaylistFor(viewerId)
+        : canControlPlayback;
+  }
+
   static PlaylistEntryGestureIntent? tapIntent({
     required RoomMediaEntry entry,
     required bool selectionMode,

--- a/lib/features/room/presentation/room_screen.dart
+++ b/lib/features/room/presentation/room_screen.dart
@@ -6544,10 +6544,15 @@ class _RoomScreenState extends State<RoomScreen>
     RoomMediaEntry entry,
     bool selectionMode,
   ) {
+    final canActivate = PlaylistSelectionPolicy.canActivate(
+      entry: entry,
+      viewerId: _currentUser?.id ?? '',
+      canControlPlayback: _canControlPlaybackState,
+    );
     final intent = PlaylistSelectionPolicy.tapIntent(
       entry: entry,
       selectionMode: selectionMode,
-      canActivate: entry.isPlaylist || _canControlPlaybackState,
+      canActivate: canActivate,
     );
     return intent == null
         ? null
@@ -6617,6 +6622,13 @@ class _RoomScreenState extends State<RoomScreen>
     Color primaryColor,
   ) {
     if (isCurrent) return primaryColor;
+    if (!PlaylistSelectionPolicy.canActivate(
+      entry: entry,
+      viewerId: _currentUser?.id ?? '',
+      canControlPlayback: _canControlPlaybackState,
+    )) {
+      return Theme.of(context).disabledColor;
+    }
     final provider = SourceConfigCodec.providerToString(entry.sourceProvider);
     if (provider.isNotEmpty) {
       final brand = mediaProviderBrand(provider);
@@ -6635,6 +6647,12 @@ class _RoomScreenState extends State<RoomScreen>
 
   String _playlistEntryShortMeta(RoomMediaEntry entry) {
     final parts = <String>[_playlistEntryTypeLabel(entry)];
+    if (!entry.isAvailable) {
+      parts.add(context.l10n.creatorUnavailable);
+    } else if (entry.isPlaylist &&
+        !entry.canBrowsePlaylistFor(_currentUser?.id ?? '')) {
+      parts.add(context.l10n.playlistBrowseAccessModeCreatorOnly);
+    }
     if (entry.isPlaylist && entry.itemCount > 0) {
       parts.add(context.l10n.itemCount(entry.itemCount));
     }
@@ -6650,12 +6668,18 @@ class _RoomScreenState extends State<RoomScreen>
 
   List<String> _playlistEntryChips(RoomMediaEntry entry) {
     final chips = <String>[_playlistEntryTypeLabel(entry)];
+    if (!entry.isAvailable) {
+      chips.add(context.l10n.creatorUnavailable);
+    } else if (entry.isPlaylist &&
+        !entry.canBrowsePlaylistFor(_currentUser?.id ?? '')) {
+      chips.add(context.l10n.playlistBrowseAccessModeCreatorOnly);
+    }
     if (entry.isPlaylist) {
-      chips.add(
-        entry.itemCount > 0
-            ? context.l10n.itemCount(entry.itemCount)
-            : context.l10n.openable,
-      );
+      if (entry.itemCount > 0) {
+        chips.add(context.l10n.itemCount(entry.itemCount));
+      } else if (entry.canBrowsePlaylistFor(_currentUser?.id ?? '')) {
+        chips.add(context.l10n.openable);
+      }
     }
     final provider = _playlistProviderLabel(entry);
     if (provider.isNotEmpty) chips.add(provider);

--- a/lib/features/room/presentation/room_settings_page.dart
+++ b/lib/features/room/presentation/room_settings_page.dart
@@ -45,6 +45,7 @@ import 'package:synctv_app/src/generated/proto/providers/common.pb.dart'
 import 'package:synctv_app/features/room/presentation/widgets/chat_read_receipts_dialog.dart';
 import 'package:synctv_app/features/room/presentation/widgets/chat_reaction_users_dialog.dart';
 import 'package:synctv_app/features/room/presentation/widgets/free_mode_settings_fields.dart';
+import 'package:synctv_app/features/room/presentation/models/playlist_selection_policy.dart';
 import 'package:synctv_app/features/media_p2p/presentation/p2p_media_settings_fields.dart';
 import 'package:synctv_app/features/room/presentation/widgets/playback_history_list.dart';
 import 'package:synctv_app/features/room/presentation/widgets/realtime_event_log_view.dart';
@@ -1775,17 +1776,18 @@ class _RoomSettingsPageState extends State<RoomSettingsPage>
       _mediaTarget.isEmpty && !_isInsideDynamicMediaPlaylist;
 
   bool _canOpenMediaEntry(RoomMediaEntry entry) {
-    if (!entry.isPlaylist) return false;
-    final isPersistedPlaylist = entry.id.startsWith('pl_');
-    if (isPersistedPlaylist && entry.isDynamicPlaylist) {
-      return entry.creator.isNotEmpty && entry.creator == _currentUserId;
-    }
-    return true;
+    return PlaylistSelectionPolicy.canActivate(
+      entry: entry,
+      viewerId: _currentUserId,
+      canControlPlayback: false,
+    );
   }
 
   Future<void> _openMediaEntry(RoomMediaEntry entry) async {
     if (!_canOpenMediaEntry(entry)) {
-      if (entry.isDynamicPlaylist) {
+      if (!entry.isAvailable) {
+        AppNotifications.showError(context, context.l10n.creatorUnavailable);
+      } else if (entry.isPlaylist) {
         AppNotifications.showError(
           context,
           context.l10n.dynamicPlaylistCreatorOnly,
@@ -6646,7 +6648,10 @@ class _RoomSettingsPageState extends State<RoomSettingsPage>
       final mode = entry.metadata['isDynamic'] == true
           ? context.l10n.dynamicPlaylist
           : context.l10n.playlist;
-      if (entry.isDynamicPlaylist && !_canOpenMediaEntry(entry)) {
+      if (!entry.isAvailable) {
+        return '$mode · ${context.l10n.creatorUnavailable}';
+      }
+      if (!_canOpenMediaEntry(entry)) {
         return context.l10n.creatorOnlyMode(mode);
       }
       final provider = SourceConfigCodec.providerToString(entry.sourceProvider);
@@ -6654,7 +6659,11 @@ class _RoomSettingsPageState extends State<RoomSettingsPage>
     }
     if (entry.id.startsWith('med_')) {
       final provider = SourceConfigCodec.providerToString(entry.sourceProvider);
-      return '$provider · ${entry.providerInstanceName.isEmpty ? 'default' : entry.providerInstanceName}';
+      final details =
+          '$provider · ${entry.providerInstanceName.isEmpty ? 'default' : entry.providerInstanceName}';
+      return entry.isAvailable
+          ? details
+          : '$details · ${context.l10n.creatorUnavailable}';
     }
     final size = entry.metadata['size'];
     return entry.isPlaylist

--- a/test/contracts/room_media_models_test.dart
+++ b/test/contracts/room_media_models_test.dart
@@ -5,6 +5,80 @@ import 'package:synctv_app/src/generated/proto/client.pbenum.dart'
     as client_enum;
 
 void main() {
+  group('media lifecycle and playlist browse access', () {
+    test('creator-inactive entries remain visible but cannot activate', () {
+      final media = RoomMediaItem(
+        id: 'med_1',
+        name: 'Unavailable media',
+        url: 'https://example.test/media.mp4',
+        availability: client_enum
+            .ResourceAvailability
+            .RESOURCE_AVAILABILITY_CREATOR_INACTIVE,
+      );
+      final playlist = RoomPlaylistItem(
+        id: 'pl_1',
+        name: 'Unavailable playlist',
+        creator: 'usr_creator',
+        availability: client_enum
+            .ResourceAvailability
+            .RESOURCE_AVAILABILITY_CREATOR_INACTIVE,
+        metadata: const {'isDynamic': true},
+      );
+
+      expect(media.isAvailable, isFalse);
+      expect(playlist.isAvailable, isFalse);
+      expect(playlist.canBrowsePlaylistFor('usr_creator'), isFalse);
+    });
+
+    test('default browse access follows static and dynamic playlist kinds', () {
+      final staticPlaylist = RoomPlaylistItem(
+        id: 'pl_static',
+        name: 'Static playlist',
+        creator: 'usr_creator',
+      );
+      final dynamicPlaylist = RoomPlaylistItem(
+        id: 'pl_dynamic',
+        name: 'Dynamic playlist',
+        creator: 'usr_creator',
+        metadata: const {'isDynamic': true},
+      );
+
+      expect(staticPlaylist.canBrowsePlaylistFor('usr_member'), isTrue);
+      expect(staticPlaylist.canBrowsePlaylistFor(''), isFalse);
+      expect(dynamicPlaylist.canBrowsePlaylistFor('usr_creator'), isTrue);
+      expect(dynamicPlaylist.canBrowsePlaylistFor('usr_member'), isFalse);
+    });
+
+    test('room-member mode shares dynamic playlist browsing', () {
+      final playlist = RoomPlaylistItem(
+        id: 'pl_shared',
+        name: 'Shared dynamic playlist',
+        creator: 'usr_creator',
+        browseAccessMode: client_enum
+            .PlaylistBrowseAccessMode
+            .PLAYLIST_BROWSE_ACCESS_MODE_ROOM_MEMBERS,
+        metadata: const {'isDynamic': true},
+      );
+
+      expect(playlist.canBrowsePlaylistFor('usr_member'), isTrue);
+      expect(playlist.canBrowsePlaylistFor(''), isFalse);
+    });
+
+    test('explicit creator-only mode also restricts static playlists', () {
+      final playlist = RoomPlaylistItem(
+        id: 'pl_private_static',
+        name: 'Creator-only static playlist',
+        creator: 'usr_creator',
+        browseAccessMode: client_enum
+            .PlaylistBrowseAccessMode
+            .PLAYLIST_BROWSE_ACCESS_MODE_CREATOR_ONLY,
+      );
+
+      expect(playlist.canBrowsePlaylistFor('usr_creator'), isTrue);
+      expect(playlist.canBrowsePlaylistFor('usr_member'), isFalse);
+    });
+  });
+
   test('media library counts provider dynamic entries in scope summary', () {
     final page = RoomMediaLibraryPage(
       playlists: const [],

--- a/test/features/room/data/room_realtime_codec_test.dart
+++ b/test/features/room/data/room_realtime_codec_test.dart
@@ -50,6 +50,30 @@ void main() {
     );
   });
 
+  test('empty playback state clears the authoritative playback source', () {
+    final encoded = client.ServerMessage(
+      resourceEvent: client.ResourceEvent(
+        observeId: 'playback_state',
+        playbackState: client.PlaybackState(
+          isPlaying: false,
+          position: 0,
+          speed: 1,
+          version: Int64(9),
+        ),
+      ),
+    ).writeToBuffer();
+
+    final decoded = RoomRealtimeCodec.decode(Uint8List.fromList(encoded));
+    final status = decoded.playbackStatus!;
+
+    expect(decoded.kind, RoomRealtimeMessageKind.status);
+    expect(status.entry, isNull);
+    expect(status.playingMediaId, isEmpty);
+    expect(status.playingPlaylistId, isEmpty);
+    expect(status.isPlaying, isFalse);
+    expect(status.version, 9);
+  });
+
   test('system chat messages use the product identity', () {
     expect(
       chatMessageDisplayUsername(

--- a/test/features/room/presentation/models/playback_player_update_test.dart
+++ b/test/features/room/presentation/models/playback_player_update_test.dart
@@ -262,4 +262,24 @@ void main() {
       PlaybackPlayerUpdateAction.dispose,
     );
   });
+
+  test('an authoritative empty source disposes the active player', () {
+    final previous = RoomPlaybackEntry(
+      id: 'med_vod',
+      name: 'Video',
+      url: 'https://example.test/video.mp4',
+    );
+
+    expect(
+      playbackPlayerUpdateAction(
+        previous: previous,
+        next: null,
+        hasController: true,
+        controllerHasPlayed: true,
+        isDrainingEndedLiveStream: false,
+        samePlayerSource: false,
+      ),
+      PlaybackPlayerUpdateAction.dispose,
+    );
+  });
 }

--- a/test/features/room/presentation/playlist_selection_interaction_test.dart
+++ b/test/features/room/presentation/playlist_selection_interaction_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:synctv_app/contracts/synctv_models.dart';
 import 'package:synctv_app/features/room/presentation/models/playlist_selection_policy.dart';
+import 'package:synctv_app/src/generated/proto/client.pbenum.dart'
+    as client_enum;
 
 void main() {
   testWidgets('selection works without exposing delete permission', (
@@ -89,6 +91,32 @@ void main() {
     expect(find.text('Selected 1'), findsOneWidget);
     expect(find.byKey(const Key('delete-selection')), findsNothing);
   });
+
+  testWidgets('activation respects lifecycle and playlist browse access', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: _SelectionHarness(canDeleteMedia: false, canClearMedia: false),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('entry-shared-dynamic-playlist')));
+    await tester.pump();
+    expect(find.text('Activated shared-dynamic-playlist'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('entry-unavailable-media')));
+    await tester.pump();
+    expect(find.text('Activated shared-dynamic-playlist'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('entry-creator-only-playlist')));
+    await tester.pump();
+    expect(find.text('Activated shared-dynamic-playlist'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('entry-opaque-media-a')));
+    await tester.pump();
+    expect(find.text('Activated opaque-media-a'), findsOneWidget);
+  });
 }
 
 class _SelectionHarness extends StatefulWidget {
@@ -117,6 +145,7 @@ class _SelectionHarnessState extends State<_SelectionHarness> {
     RoomPlaylistItem(
       id: 'opaque-dynamic-playlist',
       name: 'Dynamic playlist',
+      creator: 'usr_viewer',
       metadata: const {'isDynamic': true},
     ),
     RoomDynamicMediaEntry(
@@ -126,15 +155,40 @@ class _SelectionHarnessState extends State<_SelectionHarness> {
       subPath: '/child',
       isPlaylist: false,
     ),
+    RoomPlaylistItem(
+      id: 'shared-dynamic-playlist',
+      name: 'Shared dynamic playlist',
+      creator: 'usr_creator',
+      browseAccessMode: client_enum
+          .PlaylistBrowseAccessMode
+          .PLAYLIST_BROWSE_ACCESS_MODE_ROOM_MEMBERS,
+      metadata: const {'isDynamic': true},
+    ),
+    RoomPlaylistItem(
+      id: 'creator-only-playlist',
+      name: 'Creator-only playlist',
+      creator: 'usr_creator',
+      metadata: const {'isDynamic': true},
+    ),
+    RoomMediaItem(
+      id: 'unavailable-media',
+      name: 'Unavailable media',
+      url: 'https://example.test/unavailable.mp4',
+      availability: client_enum
+          .ResourceAvailability
+          .RESOURCE_AVAILABILITY_CREATOR_INACTIVE,
+    ),
   ];
 
   final selectedIds = <String>{};
   bool selectionMode = false;
+  String activatedId = '';
 
   void _apply(RoomMediaEntry entry, PlaylistEntryGestureIntent intent) {
     setState(() {
       switch (intent) {
         case PlaylistEntryGestureIntent.activate:
+          activatedId = entry.id;
           return;
         case PlaylistEntryGestureIntent.enterSelection:
           selectionMode = true;
@@ -156,6 +210,7 @@ class _SelectionHarnessState extends State<_SelectionHarness> {
       body: Column(
         children: [
           Text('Selected ${selectedIds.length}'),
+          Text('Activated $activatedId'),
           if (selectionMode && widget.canDeleteMedia && !widget.readOnlyScope)
             const Icon(Icons.delete_outline, key: Key('delete-selection')),
           if (widget.canClearMedia)
@@ -167,10 +222,15 @@ class _SelectionHarnessState extends State<_SelectionHarness> {
   }
 
   Widget _buildEntry(RoomMediaEntry entry) {
+    final canActivate = PlaylistSelectionPolicy.canActivate(
+      entry: entry,
+      viewerId: 'usr_viewer',
+      canControlPlayback: true,
+    );
     final tapIntent = PlaylistSelectionPolicy.tapIntent(
       entry: entry,
       selectionMode: selectionMode,
-      canActivate: true,
+      canActivate: canActivate,
     );
     final longPressIntent = PlaylistSelectionPolicy.longPressIntent(
       entry: entry,


### PR DESCRIPTION
## Summary

- stop local playback when the server clears playback authoritatively
- show creator-inactive media and dynamic playlists as unavailable while keeping them visible for management
- enforce effective playlist browse access before navigating, including dynamic defaults and explicit creator-only static playlists
- keep ordinary static playlists browsable after their creator becomes inactive
- cover lifecycle and browse-access policy with model and widget interaction tests

## Validation

- `flutter analyze`
- `flutter test` (844 passed)
- targeted lifecycle model and widget tests (10 passed)
- real macOS client verification against a local backend with separate owner, active creator, inactive creator, and viewer accounts
- verified shared dynamic browsing with live Bilibili data, creator-only access from both viewer and creator perspectives, disabled unavailable entries, retained static playlist browsing, and active media playback