### PR TITLE
release: prepare v1.1.23

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.22+21
+version: 1.1.23+22
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## Summary

- bump the app to v1.1.23+22
- release the latest upstream main commit with personal user blocking

## Verification

- `fvm flutter analyze`
- `fvm flutter test --reporter compact`
- `fvm flutter build macos --release --dart-define=SYNCTV_BUILT_IN_SERVER_URL=https://syncs.tv`