### PR TITLE
perf: keep startup responsive during slow server loads

### DIFF
--- a/lib/data/synctv_api/synctv_runtime_service.dart
+++ b/lib/data/synctv_api/synctv_runtime_service.dart
@@ -6,19 +6,26 @@ import 'package:synctv_app/core/network/server_endpoint_identity.dart';
 import 'package:synctv_app/data/synctv_api/synctv_session_store.dart';
 import 'package:synctv_app/src/generated/proto/client.pb.dart' as client;
 
+typedef SyncTvServerInfoProbe =
+    Future<client.GetServerInfoResponse> Function(SyncTvApiClient api);
+
 class SyncTvRuntimeService {
-  SyncTvRuntimeService() : session = SyncTvSession() {
+  static const serverProbeTimeout = Duration(seconds: 8);
+
+  SyncTvRuntimeService({this.serverInfoProbe}) : session = SyncTvSession() {
     sessionStore = SyncTvSessionStore(session);
     _api = _createClient(SyncTvSessionStore.clientBootstrapBaseUrl);
   }
 
   final SyncTvSession session;
+  final SyncTvServerInfoProbe? serverInfoProbe;
   late final SyncTvSessionStore sessionStore;
   late SyncTvApiClient _api;
   final StreamController<void> _authErrorController =
       StreamController<void>.broadcast();
   final Set<({SyncTvApiClient source, int generation})> _authErrorsInFlight =
       {};
+  int _serverSelectionRevision = 0;
 
   SyncTvApiClient get api => _api;
   Stream<void> get onAuthError => _authErrorController.stream;
@@ -33,16 +40,20 @@ class SyncTvRuntimeService {
 
   Future<void> init() async {
     await sessionStore.load();
+    final previousApi = _api;
     _api = _createClient(
       sessionStore.baseUrl.isEmpty
           ? SyncTvSessionStore.clientBootstrapBaseUrl
           : sessionStore.baseUrl,
       allowInsecureTls: allowInsecureTls,
     );
-    await _promotePendingActiveServer();
+    previousApi.close();
+    final revision = ++_serverSelectionRevision;
+    unawaited(_promotePendingActiveServer(revision));
   }
 
   Future<void> setBaseUrl(String url) async {
+    _serverSelectionRevision++;
     _api.configureServer(url, allowInsecureTls: false);
     await sessionStore.setBaseUrl(_api.baseUrl);
   }
@@ -53,10 +64,11 @@ class SyncTvRuntimeService {
   }) async {
     final serverClient = _createClient(url, allowInsecureTls: allowInsecureTls);
     try {
-      final info = await serverClient.publicService.getServerInfo(
-        client.GetServerInfoRequest(),
-      );
+      final info = await _getServerInfo(
+        serverClient,
+      ).timeout(serverProbeTimeout);
       final declaredServerId = info.serverId.trim();
+      _serverSelectionRevision++;
       _api.configureServer(
         serverClient.baseUrl,
         allowInsecureTls: allowInsecureTls,
@@ -80,6 +92,7 @@ class SyncTvRuntimeService {
     final target = servers.firstWhere(
       (server) => server.endpoint == normalized,
     );
+    _serverSelectionRevision++;
     _api.configureServer(normalized, allowInsecureTls: target.allowInsecureTls);
     await sessionStore.activateServer(normalized);
   }
@@ -87,6 +100,7 @@ class SyncTvRuntimeService {
   Future<void> removeServer(String endpoint) async {
     final normalized = ServerEndpointIdentity.normalize(endpoint);
     if (activeServer?.endpoint == normalized) {
+      _serverSelectionRevision++;
       final next = servers
           .where((server) => server.endpoint != normalized)
           .firstOrNull;
@@ -225,28 +239,40 @@ class SyncTvRuntimeService {
     _handleAuthError(_api, _api.endpointGeneration);
   }
 
-  Future<void> _promotePendingActiveServer() async {
+  Future<client.GetServerInfoResponse> _getServerInfo(SyncTvApiClient api) =>
+      serverInfoProbe?.call(api) ??
+      api.publicService.getServerInfo(client.GetServerInfoRequest());
+
+  Future<void> _promotePendingActiveServer(int revision) async {
     final active = sessionStore.activeServer;
     if (active == null || !active.isPending) return;
+    final endpoint = active.endpoint;
+    final serverClient = _createClient(
+      endpoint,
+      allowInsecureTls: active.allowInsecureTls,
+    );
     try {
-      final info = await _api.publicService.getServerInfo(
-        client.GetServerInfoRequest(),
-      );
+      final info = await _getServerInfo(
+        serverClient,
+      ).timeout(serverProbeTimeout);
       final declaredServerId = info.serverId.trim();
       if (declaredServerId.isEmpty) return;
+      if (revision != _serverSelectionRevision ||
+          !servers.any((server) => server.endpoint == endpoint)) {
+        return;
+      }
       await sessionStore.addOrUpdateServer(
         declaredServerId: declaredServerId,
         name: info.serverName,
-        endpoint: _api.baseUrl,
+        endpoint: endpoint,
         allowInsecureTls: active.allowInsecureTls,
-      );
-      _api.configureServer(
-        sessionStore.baseUrl,
-        allowInsecureTls: active.allowInsecureTls,
+        activate: false,
       );
     } catch (_) {
       // Keep the pending profile usable offline; the next successful launch or
       // manual server edit can promote it to the server-provided identity.
+    } finally {
+      serverClient.close();
     }
   }
 }

--- a/lib/data/synctv_api/synctv_service.dart
+++ b/lib/data/synctv_api/synctv_service.dart
@@ -57,6 +57,8 @@ export 'package:synctv_app/contracts/room_media_models.dart';
 export 'package:synctv_app/data/synctv_api/synctv_file_upload_service.dart';
 
 class SyncTvService {
+  static const _serverTimeSyncTimeout = Duration(seconds: 5);
+
   static String get baseUrl => _runtime.baseUrl;
   static List<SyncTvServerProfile> get servers => _runtime.servers;
   static SyncTvServerProfile? get activeServer => _runtime.activeServer;
@@ -71,12 +73,14 @@ class SyncTvService {
   static final SyncTvRuntimeService _runtime = SyncTvRuntimeService();
   static SyncTvApiClient get _api => _runtime.api;
   static SyncTvDomainServices _domains = _createDomains();
+  static int _serverTimeSyncRevision = 0;
 
   static Stream<void> get onAuthError => _runtime.onAuthError;
 
   static Future<void> init() async {
     await _runtime.init();
     _domains = _createDomains();
+    _invalidateServerTime();
   }
 
   static SyncTvDomainServices _createDomains() {
@@ -86,6 +90,7 @@ class SyncTvService {
   static Future<void> setBaseUrl(String url) async {
     await _runtime.setBaseUrl(url);
     _domains = _createDomains();
+    _invalidateServerTime();
   }
 
   static Future<SyncTvServerProfile> addServer(
@@ -97,17 +102,23 @@ class SyncTvService {
       allowInsecureTls: allowInsecureTls,
     );
     _domains = _createDomains();
+    _invalidateServerTime();
     return profile;
   }
 
   static Future<void> activateServer(String endpoint) async {
     await _runtime.activateServer(endpoint);
     _domains = _createDomains();
+    _invalidateServerTime();
   }
 
   static Future<void> removeServer(String endpoint) async {
+    final previousEndpoint = activeServer?.endpoint;
     await _runtime.removeServer(endpoint);
     _domains = _createDomains();
+    if (activeServer?.endpoint != previousEndpoint) {
+      _invalidateServerTime();
+    }
   }
 
   static Future<String?> getToken() => _runtime.getToken();
@@ -382,10 +393,18 @@ class SyncTvService {
 
   static Future<void> syncServerTime({bool refresh = false}) async {
     if (!refresh && SyncedClock.isSynced) return;
+    final revision = ++_serverTimeSyncRevision;
+    final endpointGeneration = _api.endpointGeneration;
     try {
       final sentAt = SyncedClock.localUnixNanos();
-      final response = await getServerTime(clientSentAtNanos: sentAt);
+      final response = await getServerTime(
+        clientSentAtNanos: sentAt,
+      ).timeout(_serverTimeSyncTimeout);
       final receivedAt = SyncedClock.localUnixNanos();
+      if (revision != _serverTimeSyncRevision ||
+          !_api.isEndpointGenerationCurrent(endpointGeneration)) {
+        return;
+      }
       SyncedClock.updateFromServerTime(
         clientSentAtNanos: response.clientSentAtNanos.toInt(),
         clientReceivedAtNanos: receivedAt,
@@ -393,8 +412,16 @@ class SyncTvService {
         serverSentAtNanos: response.serverSentAtNanos.toInt(),
       );
     } catch (_) {
-      SyncedClock.reset();
+      if (revision == _serverTimeSyncRevision &&
+          _api.isEndpointGenerationCurrent(endpointGeneration)) {
+        SyncedClock.reset();
+      }
     }
+  }
+
+  static void _invalidateServerTime() {
+    _serverTimeSyncRevision++;
+    SyncedClock.reset();
   }
 
   static Future<List<RoomCategoryInfo>> listRoomCategories({

--- a/lib/features/account/presentation/account_center_page.dart
+++ b/lib/features/account/presentation/account_center_page.dart
@@ -222,6 +222,10 @@ class _AccountCenterPageState extends State<AccountCenterPage>
   bool _loadingRooms = false;
   int _blockedUsersPage = 1;
   bool _loadingBlockedUsers = false;
+  int _loadRevision = 0;
+  int _notificationLoadRevision = 0;
+  int _roomLoadRevision = 0;
+  int _blockedUserLoadRevision = 0;
   client_enum.MyRoomRelation _roomRelationFilter =
       client_enum.MyRoomRelation.MY_ROOM_RELATION_ALL;
   client_enum.MyRoomListSortBy _roomSortBy =
@@ -268,6 +272,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
 
   @override
   void dispose() {
+    _loadRevision++;
     _tabController.dispose();
     _notificationSearchController.dispose();
     _roomSearchController.dispose();
@@ -276,121 +281,162 @@ class _AccountCenterPageState extends State<AccountCenterPage>
   }
 
   Future<void> _load({bool refresh = false}) async {
-    setState(() => _loading = true);
-    try {
-      final errors = <String, String>{};
-      final user = await _gateway.getCurrentUser(refresh: refresh);
-      final publicSettings = await _loadOptional(
-        errors,
-        _modulePublicSettings,
-        () => _gateway.getPublicSettings(refresh: refresh),
-      );
-      final serverPasskeyEnabled = publicSettings?.enableWebauthn == true;
-      final results = await Future.wait<dynamic>([
-        _loadOptional(
-          errors,
-          _moduleAccountPreferences,
-          () => _gateway.getPreferences(refresh: refresh),
+    final revision = ++_loadRevision;
+    final notificationRevision = ++_notificationLoadRevision;
+    final roomRevision = ++_roomLoadRevision;
+    final blockedUserRevision = ++_blockedUserLoadRevision;
+    setState(() {
+      _loading = true;
+      _loadingNotifications = true;
+      _loadingRooms = true;
+      _loadingBlockedUsers = true;
+      _loadErrors = const {};
+    });
+
+    final publicSettings = _loadModule<PublicSettingsInfo>(
+      revision: revision,
+      label: _modulePublicSettings,
+      load: () => _gateway.getPublicSettings(refresh: refresh),
+      apply: (value) => _publicSettings = value,
+    );
+    final operations = <Future<void>>[
+      _loadCurrentUser(revision, refresh: refresh),
+      _loadModule<AccountPreferences>(
+        revision: revision,
+        label: _moduleAccountPreferences,
+        load: () => _gateway.getPreferences(refresh: refresh),
+        apply: (value) => _preferences = value,
+      ),
+      _loadModule<UserNotificationsPage>(
+        revision: revision,
+        label: _moduleNotifications,
+        load: () => _gateway.listNotifications(
+          page: _notificationPage,
+          pageSize: _notificationPageSize,
+          refresh: refresh,
         ),
-        _loadOptional(
-          errors,
-          _moduleNotifications,
-          () => _gateway.listNotifications(
-            page: _notificationPage,
-            pageSize: _notificationPageSize,
-            refresh: refresh,
+        apply: (value) => _notifications = value,
+        onComplete: () => _loadingNotifications = false,
+        isModuleCurrent: () =>
+            notificationRevision == _notificationLoadRevision,
+      ),
+      _loadModule<RoomsPage>(
+        revision: revision,
+        label: _moduleRooms,
+        load: () => _gateway.getRooms(
+          page: _roomsPage,
+          pageSize: _roomsPageSize,
+          relation: _roomRelationFilter,
+          sortBy: _roomSortBy,
+        ),
+        apply: (value) => _myRooms = value,
+        onComplete: () => _loadingRooms = false,
+        isModuleCurrent: () => roomRevision == _roomLoadRevision,
+      ),
+      _loadModule<BlockedUsersPage>(
+        revision: revision,
+        label: _moduleBlockedUsers,
+        load: () => _gateway.listBlockedUsers(
+          page: _blockedUsersPage,
+          pageSize: _blockedUsersPageSize,
+          search: _blockedUserSearchController.text.trim(),
+        ),
+        apply: (value) => _blockedUsers = value,
+        onComplete: () => _loadingBlockedUsers = false,
+        isModuleCurrent: () => blockedUserRevision == _blockedUserLoadRevision,
+      ),
+      if (ProviderDistributionPolicy.current.allowsOAuth2) ...[
+        _loadModule<List<OAuth2ProviderOption>>(
+          revision: revision,
+          label: _moduleOAuthProviders,
+          load: _gateway.listOAuth2Providers,
+          apply: (value) => _availableOAuth2 = value,
+        ),
+        _loadModule<List<OAuth2LinkedAccount>>(
+          revision: revision,
+          label: _moduleOAuthLinks,
+          load: _gateway.getLinkedOAuth2Accounts,
+          apply: (value) => _linkedOAuth2 = value,
+        ),
+      ],
+      publicSettings.then((settings) async {
+        if (!_isCurrentLoad(revision)) return;
+        if (settings?.enableWebauthn != true) {
+          setState(() {
+            _passkeys = const [];
+            _passkeyAvailable = false;
+          });
+          return;
+        }
+        await Future.wait([
+          _loadModule<List<PasskeyCredentialInfo>>(
+            revision: revision,
+            label: _modulePasskeys,
+            load: () => _gateway.listPasskeys(refresh: refresh),
+            apply: (value) => _passkeys = value,
           ),
-        ),
-        _loadOptional(
-          errors,
-          _moduleRooms,
-          () => _gateway.getRooms(
-            page: _roomsPage,
-            pageSize: _roomsPageSize,
-            relation: _roomRelationFilter,
-            sortBy: _roomSortBy,
-          ),
-        ),
-        if (ProviderDistributionPolicy.current.allowsOAuth2)
-          _loadOptional(
-            errors,
-            _moduleOAuthProviders,
-            _gateway.listOAuth2Providers,
-          )
-        else
-          Future<List<OAuth2ProviderOption>?>.value(const []),
-        if (ProviderDistributionPolicy.current.allowsOAuth2)
-          _loadOptional(
-            errors,
-            _moduleOAuthLinks,
-            _gateway.getLinkedOAuth2Accounts,
-          )
-        else
-          Future<List<OAuth2LinkedAccount>?>.value(const []),
-        if (serverPasskeyEnabled)
-          _loadOptional(
-            errors,
-            _modulePasskeys,
-            () => _gateway.listPasskeys(refresh: refresh),
-          )
-        else
-          Future<List<PasskeyCredentialInfo>?>.value(const []),
-        if (serverPasskeyEnabled)
-          _loadOptional(
-            errors,
-            _moduleLocalPasskey,
-            () => _passkeysClient.isSupported(
+          _loadModule<bool>(
+            revision: revision,
+            label: _moduleLocalPasskey,
+            load: () => _passkeysClient.isSupported(
               serverBaseUrl: _gateway.serverBaseUrl,
-              rpId: publicSettings!.webauthnRpId,
+              rpId: settings!.webauthnRpId,
             ),
-          )
-        else
-          Future<bool?>.value(false),
-        _loadOptional(
-          errors,
-          _moduleBlockedUsers,
-          () => _gateway.listBlockedUsers(
-            page: _blockedUsersPage,
-            pageSize: _blockedUsersPageSize,
-            search: _blockedUserSearchController.text.trim(),
+            apply: (value) => _passkeyAvailable = value,
           ),
-        ),
-      ]);
-      if (!mounted) return;
-      setState(() {
-        _user = user;
-        _publicSettings = publicSettings;
-        _preferences = results[0] as AccountPreferences?;
-        _notifications = results[1] as UserNotificationsPage?;
-        _myRooms = results[2] as RoomsPage?;
-        _availableOAuth2 =
-            results[3] as List<OAuth2ProviderOption>? ?? const [];
-        _linkedOAuth2 = results[4] as List<OAuth2LinkedAccount>? ?? const [];
-        _passkeys = results[5] as List<PasskeyCredentialInfo>? ?? const [];
-        _passkeyAvailable = results[6] as bool? ?? false;
-        _blockedUsers = results[7] as BlockedUsersPage?;
-        _loadErrors = Map.unmodifiable(errors);
-        _loading = false;
-      });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _loading = false);
-      AppNotifications.showError(context, context.l10n.loadAccountFailed('$e'));
+        ]);
+      }),
+    ];
+
+    await Future.wait(operations);
+    if (_isCurrentLoad(revision)) setState(() => _loading = false);
+  }
+
+  bool _isCurrentLoad(int revision) => mounted && revision == _loadRevision;
+
+  Future<void> _loadCurrentUser(int revision, {required bool refresh}) async {
+    try {
+      final user = await _gateway.getCurrentUser(refresh: refresh);
+      if (_isCurrentLoad(revision)) setState(() => _user = user);
+    } catch (error) {
+      if (!mounted || revision != _loadRevision) return;
+      AppNotifications.showError(
+        context,
+        context.l10n.loadAccountFailed('$error'),
+      );
     }
   }
 
-  Future<T?> _loadOptional<T>(
-    Map<String, String> errors,
-    String label,
-    Future<T> Function() load,
-  ) async {
+  Future<T?> _loadModule<T>({
+    required int revision,
+    required String label,
+    required Future<T> Function() load,
+    required ValueChanged<T> apply,
+    VoidCallback? onComplete,
+    bool Function()? isModuleCurrent,
+  }) async {
+    bool isCurrent() =>
+        _isCurrentLoad(revision) && (isModuleCurrent?.call() ?? true);
     try {
-      return await load();
+      final value = await load();
+      if (isCurrent()) {
+        setState(() {
+          apply(value);
+          _clearLoadError(label);
+        });
+      }
+      return value;
     } catch (e, stackTrace) {
       debugPrint('Account center optional load failed [$label]: $e');
       debugPrint('$stackTrace');
-      errors[label] = e.toString();
+      if (isCurrent()) {
+        setState(() => _setLoadError(label, e));
+      }
       return null;
+    } finally {
+      if (isCurrent() && onComplete != null) {
+        setState(onComplete);
+      }
     }
   }
 
@@ -1004,6 +1050,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
   }
 
   Future<void> _reloadNotifications({int? page, bool refresh = true}) async {
+    final revision = ++_notificationLoadRevision;
     var targetPage = page ?? _notificationPage;
     if (targetPage < 1) targetPage = 1;
     setState(() => _loadingNotifications = true);
@@ -1021,7 +1068,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
           refresh: refresh,
         );
       }
-      if (!mounted) return;
+      if (!mounted || revision != _notificationLoadRevision) return;
       setState(() {
         _notifications = notifications;
         _notificationPage = actualPage;
@@ -1034,7 +1081,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         _selectedNotificationIds.removeWhere((id) => !visibleIds.contains(id));
       });
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || revision != _notificationLoadRevision) return;
       setState(() {
         _loadingNotifications = false;
         _setLoadError(_moduleNotifications, e);
@@ -1255,6 +1302,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
   }
 
   Future<void> _reloadRooms({int? page, bool refresh = true}) async {
+    final revision = ++_roomLoadRevision;
     var targetPage = page ?? _roomsPage;
     if (targetPage < 1) targetPage = 1;
     setState(() => _loadingRooms = true);
@@ -1266,7 +1314,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         actualPage = maxPage;
         rooms = await _fetchRoomsPage(actualPage, refresh: refresh);
       }
-      if (!mounted) return;
+      if (!mounted || revision != _roomLoadRevision) return;
       setState(() {
         _myRooms = rooms;
         _roomsPage = actualPage;
@@ -1274,7 +1322,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         _clearLoadError(_moduleRooms);
       });
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || revision != _roomLoadRevision) return;
       setState(() {
         _loadingRooms = false;
         _setLoadError(_moduleRooms, e);
@@ -1284,6 +1332,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
   }
 
   Future<void> _reloadBlockedUsers({int? page}) async {
+    final revision = ++_blockedUserLoadRevision;
     var targetPage = page ?? _blockedUsersPage;
     if (targetPage < 1) targetPage = 1;
     setState(() => _loadingBlockedUsers = true);
@@ -1295,7 +1344,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         actualPage = maxPage;
         blockedUsers = await _fetchBlockedUsersPage(actualPage);
       }
-      if (!mounted) return;
+      if (!mounted || revision != _blockedUserLoadRevision) return;
       setState(() {
         _blockedUsers = blockedUsers;
         _blockedUsersPage = actualPage;
@@ -1303,7 +1352,7 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         _clearLoadError(_moduleBlockedUsers);
       });
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || revision != _blockedUserLoadRevision) return;
       setState(() {
         _loadingBlockedUsers = false;
         _setLoadError(_moduleBlockedUsers, e);
@@ -1584,9 +1633,15 @@ class _AccountCenterPageState extends State<AccountCenterPage>
       body: LayoutBuilder(
         builder: (context, constraints) {
           final useRail = constraints.maxWidth >= 900;
-          final content = _loading
-              ? const AppLoadingIndicator()
-              : _buildTabView(theme);
+          final content = Column(
+            children: [
+              SizedBox(
+                height: 2,
+                child: _loading ? const AppLinearProgress(minHeight: 2) : null,
+              ),
+              Expanded(child: _buildTabView(theme)),
+            ],
+          );
 
           if (!useRail) {
             return Column(
@@ -1826,19 +1881,19 @@ class _AccountCenterPageState extends State<AccountCenterPage>
               _MetricTile(
                 icon: Icons.meeting_room_outlined,
                 label: context.l10n.myRooms,
-                value: '$roomCount',
+                value: rooms == null ? '-' : '$roomCount',
                 tone: theme.colorScheme.primary,
               ),
               _MetricTile(
                 icon: Icons.notifications_none_rounded,
                 label: context.l10n.unreadNotifications,
-                value: '$unread',
+                value: _notifications == null ? '-' : '$unread',
                 tone: const Color(0xFF0F766E),
               ),
               _MetricTile(
                 icon: Icons.security_rounded,
                 label: context.l10n.loginFactors,
-                value: '$activeFactors',
+                value: preferences == null ? '-' : '$activeFactors',
                 tone: const Color(0xFFB45309),
               ),
               if (_showEmailBindingControls)
@@ -2287,7 +2342,9 @@ class _AccountCenterPageState extends State<AccountCenterPage>
           ),
         ),
         Expanded(
-          child: loadError != null && page == null
+          child: _loadingRooms && page == null
+              ? const AppLoadingIndicator()
+              : loadError != null && page == null
               ? Center(
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 520),
@@ -2423,7 +2480,9 @@ class _AccountCenterPageState extends State<AccountCenterPage>
           ),
         ),
         Expanded(
-          child: loadError != null && page == null
+          child: _loadingBlockedUsers && page == null
+              ? const AppLoadingIndicator()
+              : loadError != null && page == null
               ? Center(
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 520),
@@ -2963,7 +3022,9 @@ class _AccountCenterPageState extends State<AccountCenterPage>
           ),
         ),
         Expanded(
-          child: loadError != null && page == null
+          child: _loadingNotifications && page == null
+              ? const AppLoadingIndicator()
+              : loadError != null && page == null
               ? Center(
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 520),
@@ -3460,7 +3521,9 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         children: [
           _InfoRow(
             label: context.l10n.multiFactorAuthentication,
-            value: preferences?.twoFactorEnabled == true
+            value: preferences == null
+                ? '-'
+                : preferences.twoFactorEnabled
                 ? context.l10n.enabled
                 : context.l10n.disabled,
           ),
@@ -3497,7 +3560,9 @@ class _AccountCenterPageState extends State<AccountCenterPage>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (rooms.isEmpty)
+          if (_loadingRooms && _myRooms == null)
+            const AppLoadingIndicator(size: AppLoadingSize.sm, centered: false)
+          else if (rooms.isEmpty)
             AppEmptyMessage(
               message: context.l10n.noRooms,
               centered: false,

--- a/lib/features/app_shell/presentation/app_shell.dart
+++ b/lib/features/app_shell/presentation/app_shell.dart
@@ -138,10 +138,10 @@ class _AppShellState extends State<AppShell> {
     }
   }
 
-  Future<void> _checkLoginAndLoadData() async {
+  void _checkLoginAndLoadData() {
     unawaited(_loadRooms(silent: false));
     if (_isAccountSession) {
-      await _fetchUserInfo();
+      unawaited(_fetchUserInfo());
     }
     _openStartRoomIfRequested();
   }

--- a/lib/features/content_reports/presentation/content_reports_view.dart
+++ b/lib/features/content_reports/presentation/content_reports_view.dart
@@ -74,6 +74,7 @@ class _ContentReportsViewState extends State<ContentReportsView>
   List<AdminContentReport> _reports = const [];
   final _searchController = TextEditingController();
   TabController? _targetTypeTabController;
+  int _loadRevision = 0;
 
   static const _targetTypeTabs = <_ReportTargetTypeTab>[
     _ReportTargetTypeTab(
@@ -139,6 +140,7 @@ class _ContentReportsViewState extends State<ContentReportsView>
 
   @override
   void dispose() {
+    _loadRevision++;
     _targetTypeTabController?.removeListener(_handleTargetTypeTabChanged);
     _targetTypeTabController?.dispose();
     _searchController.dispose();
@@ -158,6 +160,7 @@ class _ContentReportsViewState extends State<ContentReportsView>
   }
 
   Future<void> _loadReports({bool silent = false}) async {
+    final revision = ++_loadRevision;
     if (!silent) setState(() => _isLoading = true);
     try {
       final data = await _gateway.list(
@@ -178,14 +181,14 @@ class _ContentReportsViewState extends State<ContentReportsView>
           search: _search,
         ),
       );
-      if (!mounted) return;
+      if (!mounted || revision != _loadRevision) return;
       setState(() {
         _reports = data.reports;
         _total = data.total;
         _isLoading = false;
       });
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || revision != _loadRevision) return;
       setState(() => _isLoading = false);
       AppNotifications.showError(context, context.l10n.loadReportsFailed('$e'));
     }
@@ -589,8 +592,14 @@ class _ContentReportsViewState extends State<ContentReportsView>
                   _loadReports();
                 },
         ),
+        SizedBox(
+          height: 2,
+          child: _isLoading && _reports.isNotEmpty
+              ? const AppLinearProgress(minHeight: 2)
+              : null,
+        ),
         Expanded(
-          child: _isLoading
+          child: _isLoading && _reports.isEmpty
               ? const AppLoadingIndicator()
               : _reports.isEmpty
               ? Center(

--- a/lib/features/home/presentation/home_view.dart
+++ b/lib/features/home/presentation/home_view.dart
@@ -118,13 +118,23 @@ class HomeView extends StatelessWidget {
         elevation: 0,
         title: _HomeHeader(state: state, callbacks: callbacks),
       ),
-      body: state.isLoading
-          ? const AppLoadingIndicator()
-          : _DiscoveryBody(
+      body: Column(
+        children: [
+          SizedBox(
+            height: 2,
+            child: state.isLoading
+                ? const AppLinearProgress(minHeight: 2)
+                : null,
+          ),
+          Expanded(
+            child: _DiscoveryBody(
               state: state,
               callbacks: callbacks,
               searchController: searchController,
             ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -729,6 +739,26 @@ class _RoomGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    if (state.isLoading && state.rooms.isEmpty) {
+      return SizedBox(
+        height: 280,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const AppLoadingIndicator(),
+              const SizedBox(height: 20),
+              AppActionButton(
+                onPressed: callbacks.openServerSettings,
+                icon: Icons.dns_rounded,
+                label: context.l10n.server,
+                style: AppActionButtonStyle.tonal,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     if (state.rooms.isEmpty) {
       return SizedBox(
         height: 280,

--- a/lib/features/home/showcase/home_showcase.dart
+++ b/lib/features/home/showcase/home_showcase.dart
@@ -137,14 +137,17 @@ final homeShowcaseRooms = <SyncTvRoom>[
 
 HomeViewState homeShowcaseState({
   List<SyncTvRoom>? rooms,
+  List<SyncTvRoom>? featuredRooms,
   String selectedCategoryId = '',
+  bool isLoading = false,
 }) => HomeViewState(
   identity: const AccountSessionIdentity(),
   hasServer: true,
-  isLoading: false,
+  isLoading: isLoading,
   isLoadingTaxonomy: false,
   rooms: rooms ?? homeShowcaseRooms,
-  featuredRooms: homeShowcaseRooms.take(5).toList(growable: false),
+  featuredRooms:
+      featuredRooms ?? homeShowcaseRooms.take(5).toList(growable: false),
   joinedRooms: homeShowcaseRooms
       .where((room) => room.joined)
       .toList(growable: false),
@@ -164,12 +167,13 @@ HomeViewState homeShowcaseState({
 );
 
 HomeViewCallbacks homeShowcaseCallbacks({
+  VoidCallback? onOpenServerSettings,
   ValueChanged<SyncTvRoom>? onOpenRoom,
   ValueChanged<SyncTvRoom>? onToggleFavorite,
   ValueChanged<String>? onSearch,
   ValueChanged<String>? onSelectCategory,
 }) => HomeViewCallbacks(
-  openServerSettings: () {},
+  openServerSettings: onOpenServerSettings ?? () {},
   openLanguageSelector: () {},
   openLogin: () {},
   openJoinRoom: () {},

--- a/lib/features/media_library/presentation/add_media_dialog.dart
+++ b/lib/features/media_library/presentation/add_media_dialog.dart
@@ -326,10 +326,31 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   ProviderAddTarget _bilibiliTarget = ProviderAddTarget.parse;
   bool _bilibiliPlaylistHasDraft = false;
 
-  List<String> _boundVendors = [];
-  bool _checkingVendors = true;
+  final Set<String> _loadingVendors = {};
+  final Map<String, int> _vendorLoadRevisions = {};
+  int _vendorErrorGeneration = 0;
+  int _notifiedVendorErrorGeneration = 0;
   PublicSettingsInfo? _publicSettings;
   bool _dependenciesInitialized = false;
+
+  bool get _checkingVendors => _loadingVendors.isNotEmpty;
+
+  List<String> get _boundVendors => [
+    if (_alistBinds.isNotEmpty) 'alist',
+    if (_embyBinds.isNotEmpty) 'emby',
+    if (_bilibiliBinds.isNotEmpty) 'bilibili',
+    if (_cloudreveBinds.isNotEmpty) 'cloudreve',
+    if (_twitchBinds.isNotEmpty) 'twitch',
+    if (_fnosBinds.isNotEmpty) 'fnos',
+    if (_qnapBinds.isNotEmpty) 'qnap',
+    if (_synologyBinds.isNotEmpty) 'synology',
+    if (_nextcloudBinds.isNotEmpty) 'nextcloud',
+    if (_seafileBinds.isNotEmpty) 'seafile',
+    if (_trueNasBinds.isNotEmpty) 'truenas',
+    if (_youtubeBinds.isNotEmpty) 'youtube',
+    if (_douyinBinds.isNotEmpty) 'douyin',
+    if (_tiktokBinds.isNotEmpty) 'tiktok',
+  ];
 
   @override
   void initState() {
@@ -353,97 +374,56 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   }
 
   Future<void> _checkVendors() async {
-    if (!widget.distributionPolicy.includesThirdPartyProviders) {
-      await _checkUserOwnedVendors();
-      return;
-    }
+    final errorGeneration = ++_vendorErrorGeneration;
+    final providerTypes = widget.distributionPolicy.includesThirdPartyProviders
+        ? const [
+            'alist',
+            'emby',
+            'bilibili',
+            'cloudreve',
+            'twitch',
+            'fnos',
+            'qnap',
+            'huya',
+            'douyu',
+            'acfun',
+            'cctv',
+            'publicSettings',
+            'synology',
+            'nextcloud',
+            'seafile',
+            'truenas',
+            'youtube',
+            'douyin',
+            'tiktok',
+          ]
+        : const [
+            'alist',
+            'emby',
+            'cloudreve',
+            'fnos',
+            'qnap',
+            'publicSettings',
+            'synology',
+            'nextcloud',
+            'seafile',
+            'truenas',
+          ];
     try {
-      final results = await Future.wait([
-        providerGateway.getAllAlistBindInfos(),
-        providerGateway.getAllEmbyBindInfos(),
-        providerGateway.getAllBilibiliBindInfos(),
-        providerGateway.getAllCloudreveBindInfos(),
-        providerGateway.getAllTwitchBindInfos(),
-        providerGateway.getAllFnosBindInfos(),
-        providerGateway.getAllQnapBindInfos(),
-        providerGateway.listAvailableProviderInstances(providerType: 'huya'),
-        providerGateway.listAvailableProviderInstances(providerType: 'douyu'),
-        providerGateway.listAvailableProviderInstances(providerType: 'acfun'),
-        providerGateway.listAvailableProviderInstances(providerType: 'cctv'),
-        providerGateway.getPublicSettings(),
-        providerGateway.getAllSynologyBindInfos(),
-        providerGateway.getAllNextcloudBindInfos(),
-        providerGateway.getAllSeafileBindInfos(),
-        providerGateway.getAllTrueNasBindInfos(),
-        providerGateway.getAllYoutubeBindInfos(),
-        providerGateway.getAllDouyinBindInfos(),
-        providerGateway.getAllTikTokBindInfos(),
-      ]);
-      final alistBinds = results[0] as List<AlistBindInfo>;
-      final embyBinds = results[1] as List<EmbyBindInfo>;
-      final bilibiliBinds = results[2] as List<BilibiliBindInfo>;
-      final cloudreveBinds = results[3] as List<CloudreveBindInfo>;
-      final twitchBinds = results[4] as List<TwitchBindInfo>;
-      final fnosBinds = results[5] as List<FnosBindInfo>;
-      final qnapBinds = results[6] as List<QnapBindInfo>;
-      final huyaInstances = results[7] as List<String>;
-      final douyuInstances = results[8] as List<String>;
-      final acfunInstances = results[9] as List<String>;
-      final cctvInstances = results[10] as List<String>;
-      final publicSettings = results[11] as PublicSettingsInfo;
-      final synologyBinds = results[12] as List<SynologyBindInfo>;
-      final nextcloudBinds = results[13] as List<NextcloudBindInfo>;
-      final seafileBinds = results[14] as List<SeafileBindInfo>;
-      final trueNasBinds = results[15] as List<TrueNasBindInfo>;
-      final youtubeBinds = results[16] as List<YoutubeBindInfo>;
-      final douyinBinds = results[17] as List<DouyinBindInfo>;
-      final tiktokBinds = results[18] as List<TikTokBindInfo>;
-      if (!mounted) return;
-      setState(() {
-        _alistBinds = alistBinds;
-        _embyBinds = embyBinds;
-        _bilibiliBinds = bilibiliBinds;
-        _cloudreveBinds = cloudreveBinds;
-        _twitchBinds = twitchBinds;
-        _fnosBinds = fnosBinds;
-        _qnapBinds = qnapBinds;
-        _synologyBinds = synologyBinds;
-        _nextcloudBinds = nextcloudBinds;
-        _seafileBinds = seafileBinds;
-        _trueNasBinds = trueNasBinds;
-        _youtubeBinds = youtubeBinds;
-        _douyinBinds = douyinBinds;
-        _tiktokBinds = tiktokBinds;
-        _huyaInstances = {'', ...huyaInstances}.toList();
-        _douyuInstances = {'', ...douyuInstances}.toList();
-        _acfunInstances = {'', ...acfunInstances}.toList();
-        _cctvInstances = {'', ...cctvInstances}.toList();
-        _publicSettings = publicSettings;
-        _boundVendors = [
-          if (alistBinds.isNotEmpty) 'alist',
-          if (embyBinds.isNotEmpty) 'emby',
-          if (bilibiliBinds.isNotEmpty) 'bilibili',
-          if (cloudreveBinds.isNotEmpty) 'cloudreve',
-          if (twitchBinds.isNotEmpty) 'twitch',
-          if (fnosBinds.isNotEmpty) 'fnos',
-          if (qnapBinds.isNotEmpty) 'qnap',
-          if (synologyBinds.isNotEmpty) 'synology',
-          if (nextcloudBinds.isNotEmpty) 'nextcloud',
-          if (seafileBinds.isNotEmpty) 'seafile',
-          if (trueNasBinds.isNotEmpty) 'truenas',
-          if (youtubeBinds.isNotEmpty) 'youtube',
-          if (douyinBinds.isNotEmpty) 'douyin',
-          if (tiktokBinds.isNotEmpty) 'tiktok',
-        ];
-        _applyDefaultProviderBindings();
-        _checkingVendors = false;
-      });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _checkingVendors = false);
+      await Future.wait(
+        providerTypes.map(
+          (providerType) =>
+              _refreshVendor(providerType, errorGeneration: errorGeneration),
+        ),
+      );
+    } catch (error) {
+      if (!mounted || _notifiedVendorErrorGeneration == errorGeneration) {
+        return;
+      }
+      _notifiedVendorErrorGeneration = errorGeneration;
       AppNotifications.showError(
         context,
-        context.l10n.loadMediaBindingsFailed('$e'),
+        context.l10n.loadMediaBindingsFailed('$error'),
       );
     }
   }
@@ -453,7 +433,7 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
       context,
       initialProviderType: providerType,
     );
-    await _checkVendors();
+    await _refreshVendor(providerType);
     if (!mounted) return;
     switch (providerType) {
       case 'alist' when _alistBinds.isNotEmpty:
@@ -465,63 +445,151 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
     }
   }
 
-  Future<void> _checkUserOwnedVendors() async {
+  Future<void> _refreshVendor(String providerType, {int? errorGeneration}) {
+    final generation = errorGeneration ?? ++_vendorErrorGeneration;
+    return switch (providerType) {
+      'alist' => _loadVendor(
+        providerType,
+        providerGateway.getAllAlistBindInfos,
+        (value) => _alistBinds = value,
+        generation,
+      ),
+      'emby' => _loadVendor(
+        providerType,
+        providerGateway.getAllEmbyBindInfos,
+        (value) => _embyBinds = value,
+        generation,
+      ),
+      'bilibili' => _loadVendor(
+        providerType,
+        providerGateway.getAllBilibiliBindInfos,
+        (value) => _bilibiliBinds = value,
+        generation,
+      ),
+      'cloudreve' => _loadVendor(
+        providerType,
+        providerGateway.getAllCloudreveBindInfos,
+        (value) => _cloudreveBinds = value,
+        generation,
+      ),
+      'twitch' => _loadVendor(
+        providerType,
+        providerGateway.getAllTwitchBindInfos,
+        (value) => _twitchBinds = value,
+        generation,
+      ),
+      'fnos' => _loadVendor(
+        providerType,
+        providerGateway.getAllFnosBindInfos,
+        (value) => _fnosBinds = value,
+        generation,
+      ),
+      'qnap' => _loadVendor(
+        providerType,
+        providerGateway.getAllQnapBindInfos,
+        (value) => _qnapBinds = value,
+        generation,
+      ),
+      'synology' => _loadVendor(
+        providerType,
+        providerGateway.getAllSynologyBindInfos,
+        (value) => _synologyBinds = value,
+        generation,
+      ),
+      'nextcloud' => _loadVendor(
+        providerType,
+        providerGateway.getAllNextcloudBindInfos,
+        (value) => _nextcloudBinds = value,
+        generation,
+      ),
+      'seafile' => _loadVendor(
+        providerType,
+        providerGateway.getAllSeafileBindInfos,
+        (value) => _seafileBinds = value,
+        generation,
+      ),
+      'truenas' => _loadVendor(
+        providerType,
+        providerGateway.getAllTrueNasBindInfos,
+        (value) => _trueNasBinds = value,
+        generation,
+      ),
+      'youtube' => _loadVendor(
+        providerType,
+        providerGateway.getAllYoutubeBindInfos,
+        (value) => _youtubeBinds = value,
+        generation,
+      ),
+      'douyin' => _loadVendor(
+        providerType,
+        providerGateway.getAllDouyinBindInfos,
+        (value) => _douyinBinds = value,
+        generation,
+      ),
+      'tiktok' => _loadVendor(
+        providerType,
+        providerGateway.getAllTikTokBindInfos,
+        (value) => _tiktokBinds = value,
+        generation,
+      ),
+      'huya' || 'douyu' || 'acfun' || 'cctv' => _loadVendor(
+        providerType,
+        () => providerGateway.listAvailableProviderInstances(
+          providerType: providerType,
+        ),
+        (value) => _setProviderInstances(providerType, value),
+        generation,
+      ),
+      'publicSettings' => _loadVendor(
+        providerType,
+        providerGateway.getPublicSettings,
+        (value) => _publicSettings = value,
+        generation,
+      ),
+      _ => Future<void>.value(),
+    };
+  }
+
+  Future<void> _loadVendor<T>(
+    String providerType,
+    Future<T> Function() load,
+    void Function(T value) apply,
+    int errorGeneration,
+  ) async {
+    final revision = (_vendorLoadRevisions[providerType] ?? 0) + 1;
+    _vendorLoadRevisions[providerType] = revision;
+    if (mounted) setState(() => _loadingVendors.add(providerType));
     try {
-      final results = await Future.wait([
-        providerGateway.getAllAlistBindInfos(),
-        providerGateway.getAllEmbyBindInfos(),
-        providerGateway.getAllCloudreveBindInfos(),
-        providerGateway.getAllFnosBindInfos(),
-        providerGateway.getAllQnapBindInfos(),
-        providerGateway.getPublicSettings(),
-        providerGateway.getAllSynologyBindInfos(),
-        providerGateway.getAllNextcloudBindInfos(),
-        providerGateway.getAllSeafileBindInfos(),
-        providerGateway.getAllTrueNasBindInfos(),
-      ]);
-      final alistBinds = results[0] as List<AlistBindInfo>;
-      final embyBinds = results[1] as List<EmbyBindInfo>;
-      final cloudreveBinds = results[2] as List<CloudreveBindInfo>;
-      final fnosBinds = results[3] as List<FnosBindInfo>;
-      final qnapBinds = results[4] as List<QnapBindInfo>;
-      final publicSettings = results[5] as PublicSettingsInfo;
-      final synologyBinds = results[6] as List<SynologyBindInfo>;
-      final nextcloudBinds = results[7] as List<NextcloudBindInfo>;
-      final seafileBinds = results[8] as List<SeafileBindInfo>;
-      final trueNasBinds = results[9] as List<TrueNasBindInfo>;
-      if (!mounted) return;
+      final value = await load();
+      if (!mounted || _vendorLoadRevisions[providerType] != revision) return;
       setState(() {
-        _alistBinds = alistBinds;
-        _embyBinds = embyBinds;
-        _cloudreveBinds = cloudreveBinds;
-        _fnosBinds = fnosBinds;
-        _qnapBinds = qnapBinds;
-        _synologyBinds = synologyBinds;
-        _nextcloudBinds = nextcloudBinds;
-        _seafileBinds = seafileBinds;
-        _trueNasBinds = trueNasBinds;
-        _publicSettings = publicSettings;
-        _boundVendors = [
-          if (alistBinds.isNotEmpty) 'alist',
-          if (embyBinds.isNotEmpty) 'emby',
-          if (cloudreveBinds.isNotEmpty) 'cloudreve',
-          if (fnosBinds.isNotEmpty) 'fnos',
-          if (qnapBinds.isNotEmpty) 'qnap',
-          if (synologyBinds.isNotEmpty) 'synology',
-          if (nextcloudBinds.isNotEmpty) 'nextcloud',
-          if (seafileBinds.isNotEmpty) 'seafile',
-          if (trueNasBinds.isNotEmpty) 'truenas',
-        ];
+        apply(value);
         _applyDefaultProviderBindings();
-        _checkingVendors = false;
+        _loadingVendors.remove(providerType);
       });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _checkingVendors = false);
+    } catch (error) {
+      if (!mounted || _vendorLoadRevisions[providerType] != revision) return;
+      setState(() => _loadingVendors.remove(providerType));
+      if (_notifiedVendorErrorGeneration == errorGeneration) return;
+      _notifiedVendorErrorGeneration = errorGeneration;
       AppNotifications.showError(
         context,
-        context.l10n.loadMediaBindingsFailed('$e'),
+        context.l10n.loadMediaBindingsFailed('$error'),
       );
+    }
+  }
+
+  void _setProviderInstances(String providerType, List<String> instances) {
+    final available = {'', ...instances}.toList();
+    switch (providerType) {
+      case 'huya':
+        _huyaInstances = available;
+      case 'douyu':
+        _douyuInstances = available;
+      case 'acfun':
+        _acfunInstances = available;
+      case 'cctv':
+        _cctvInstances = available;
     }
   }
 
@@ -895,15 +963,16 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           ),
           if (!iconOnly) ...[
             const SizedBox(height: 8),
-            if (_checkingVendors)
-              const AppLinearProgress(minHeight: 2)
-            else
-              Text(
-                context.l10n.connectedMediaSources(_boundVendors.length),
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
+            Text(
+              context.l10n.connectedMediaSources(_boundVendors.length),
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
               ),
+            ),
+            if (_checkingVendors) ...[
+              const SizedBox(height: 6),
+              const AppLinearProgress(minHeight: 2),
+            ],
           ],
         ],
       ),
@@ -1220,6 +1289,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onDraftChanged: (value) => _cctvHasDraft = value,
         );
       case 12:
+        if (_fnosBinds.isEmpty && _loadingVendors.contains('fnos')) {
+          return const AppLoadingIndicator();
+        }
         return FnosAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -1228,6 +1300,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onOpenBinding: () => _openProviderBinding('fnos'),
         );
       case 13:
+        if (_qnapBinds.isEmpty && _loadingVendors.contains('qnap')) {
+          return const AppLoadingIndicator();
+        }
         return QnapAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -1236,6 +1311,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onOpenBinding: () => _openProviderBinding('qnap'),
         );
       case 14:
+        if (_synologyBinds.isEmpty && _loadingVendors.contains('synology')) {
+          return const AppLoadingIndicator();
+        }
         return SynologyAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -1244,6 +1322,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onOpenBinding: () => _openProviderBinding('synology'),
         );
       case 15:
+        if (_nextcloudBinds.isEmpty && _loadingVendors.contains('nextcloud')) {
+          return const AppLoadingIndicator();
+        }
         return NextcloudAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -1252,6 +1333,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onOpenBinding: () => _openProviderBinding('nextcloud'),
         );
       case 16:
+        if (_seafileBinds.isEmpty && _loadingVendors.contains('seafile')) {
+          return const AppLoadingIndicator();
+        }
         return SeafileAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -1260,6 +1344,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
           onOpenBinding: () => _openProviderBinding('seafile'),
         );
       case 17:
+        if (_trueNasBinds.isEmpty && _loadingVendors.contains('truenas')) {
+          return const AppLoadingIndicator();
+        }
         return TrueNasAddMediaForm(
           roomId: widget.roomId,
           playlistId: widget.parentId ?? '',
@@ -2413,7 +2500,7 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   }
 
   Widget _buildAlistContent(ThemeData theme) {
-    if (_checkingVendors) {
+    if (_alistBinds.isEmpty && _loadingVendors.contains('alist')) {
       return const AppLoadingIndicator();
     }
     if (!_boundVendors.contains('alist')) {
@@ -2519,7 +2606,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   }
 
   Widget _buildEmbyContent(ThemeData theme) {
-    if (_checkingVendors) return const AppLoadingIndicator();
+    if (_embyBinds.isEmpty && _loadingVendors.contains('emby')) {
+      return const AppLoadingIndicator();
+    }
     if (_embyBinds.isEmpty) return _buildBindGuide('Emby', theme);
     if (!_embyPlaylistMode) return _buildEmbyLibraryContent(theme);
     return EmbyPlaylistForm(
@@ -2571,7 +2660,7 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   }
 
   Widget _buildEmbyLibraryContent(ThemeData theme) {
-    if (_checkingVendors) {
+    if (_embyBinds.isEmpty && _loadingVendors.contains('emby')) {
       return const AppLoadingIndicator();
     }
     if (!_boundVendors.contains('emby')) return _buildBindGuide('Emby', theme);
@@ -2692,7 +2781,9 @@ class _AddMediaDialogState extends State<AddMediaDialog> {
   }
 
   Widget _buildCloudreveContent(ThemeData theme) {
-    if (_checkingVendors) return const AppLoadingIndicator();
+    if (_cloudreveBinds.isEmpty && _loadingVendors.contains('cloudreve')) {
+      return const AppLoadingIndicator();
+    }
     if (!_boundVendors.contains('cloudreve')) {
       return _buildBindGuide('Cloudreve', theme);
     }

--- a/lib/features/server_settings/presentation/server_settings_dialog.dart
+++ b/lib/features/server_settings/presentation/server_settings_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:synctv_app/l10n/l10n.dart';
@@ -43,6 +45,8 @@ class _ServerSettingsSheet extends StatefulWidget {
 }
 
 class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
+  static const _serverInfoTimeout = Duration(seconds: 8);
+
   ServerConnectionGateway get _gateway =>
       DependencyScope.read<ServerConnectionGateway>(context);
 
@@ -51,6 +55,7 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
   ServerInfo? _serverInfo;
   Object? _serverInfoError;
   var _loadingServerInfo = true;
+  var _serverInfoRequestRevision = 0;
 
   @override
   void initState() {
@@ -62,24 +67,63 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
     }
   }
 
+  @override
+  void dispose() {
+    _serverInfoRequestRevision++;
+    super.dispose();
+  }
+
   Future<void> _loadServerInfo({bool refresh = false}) async {
+    final endpoint = _gateway.activeServer?.endpoint;
+    if (endpoint == null) {
+      if (mounted) {
+        setState(() {
+          _serverInfo = null;
+          _serverInfoError = null;
+          _loadingServerInfo = false;
+        });
+      }
+      return;
+    }
+    final requestRevision = ++_serverInfoRequestRevision;
     setState(() {
+      _serverInfo = null;
       _loadingServerInfo = true;
       _serverInfoError = null;
     });
     try {
-      final info = await _gateway.getServerInfo(refresh: refresh);
-      if (!mounted) return;
+      final info = await _gateway
+          .getServerInfo(refresh: refresh)
+          .timeout(_serverInfoTimeout);
+      if (!_isCurrentServerInfoRequest(requestRevision, endpoint)) return;
       setState(() {
         _serverInfo = info;
         _loadingServerInfo = false;
       });
     } catch (error) {
-      if (!mounted) return;
+      if (!_isCurrentServerInfoRequest(requestRevision, endpoint)) return;
       setState(() {
         _serverInfoError = error;
         _loadingServerInfo = false;
       });
+    }
+  }
+
+  bool _isCurrentServerInfoRequest(int revision, String endpoint) =>
+      mounted &&
+      revision == _serverInfoRequestRevision &&
+      _gateway.activeServer?.endpoint == endpoint;
+
+  void _refreshActiveServerMetadata() {
+    unawaited(_loadServerInfo(refresh: true));
+    unawaited(_syncServerTime());
+  }
+
+  Future<void> _syncServerTime() async {
+    try {
+      await _gateway.syncServerTime(refresh: true);
+    } catch (error) {
+      debugPrint('Failed to synchronize server time: $error');
     }
   }
 
@@ -100,10 +144,11 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
         context,
         context.l10n.serverConnected(profile.name),
       );
-      await _loadServerInfo(refresh: true);
-      if (!mounted) return;
+      unawaited(_syncServerTime());
       if (widget.requireServer) {
         Navigator.pop(context, true);
+      } else {
+        unawaited(_loadServerInfo(refresh: true));
       }
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -111,20 +156,19 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
   }
 
   Future<void> _activateServer(ServerConnectionProfile profile) async {
+    if (_busy) return;
     setState(() => _busy = true);
     try {
       await _gateway.activateServer(profile.endpoint);
-      await _gateway.syncServerTime(refresh: true);
-      await _loadServerInfo(refresh: true);
+      if (!mounted) return;
       _changed = true;
       widget.onServerChanged?.call();
-      if (mounted) {
-        AppNotifications.showSuccess(
-          context,
-          context.l10n.serverSwitched(profile.name),
-        );
-      }
-      setState(() {});
+      AppNotifications.showSuccess(
+        context,
+        context.l10n.serverSwitched(profile.name),
+      );
+      setState(() => _busy = false);
+      _refreshActiveServerMetadata();
     } catch (error) {
       if (mounted) {
         AppNotifications.showError(
@@ -133,7 +177,7 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
         );
       }
     } finally {
-      if (mounted) {
+      if (mounted && _busy) {
         setState(() => _busy = false);
       }
     }
@@ -150,12 +194,21 @@ class _ServerSettingsSheetState extends State<_ServerSettingsSheet> {
     setState(() => _busy = true);
     try {
       await _gateway.removeServer(profile.endpoint);
+      if (!mounted) return;
       _changed = true;
       widget.onServerChanged?.call();
-      if (mounted) {
-        AppNotifications.showSuccess(context, context.l10n.serverRemoved);
+      AppNotifications.showSuccess(context, context.l10n.serverRemoved);
+      setState(() => _busy = false);
+      if (_gateway.activeServer != null) {
+        _refreshActiveServerMetadata();
+      } else {
+        _serverInfoRequestRevision++;
+        setState(() {
+          _serverInfo = null;
+          _serverInfoError = null;
+          _loadingServerInfo = false;
+        });
       }
-      setState(() {});
     } catch (error) {
       if (mounted) {
         AppNotifications.showError(
@@ -304,7 +357,6 @@ class _AddServerDialogState extends State<_AddServerDialog> {
         input,
         allowInsecureTls: _allowInsecureTls,
       );
-      await _gateway.syncServerTime(refresh: true);
       if (mounted) Navigator.pop(context, profile);
     } on ServerConnectionException catch (error) {
       if (mounted) AppNotifications.showError(context, error.message);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:accessibility_tools/accessibility_tools.dart';
 import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter/foundation.dart';
@@ -54,68 +56,38 @@ void main(List<String> args) async {
   if (runWebViewTitleBarWidget(args)) {
     return;
   }
-  await appLocaleController.load();
-  await SyncTvService.init();
-  if (SyncTvService.activeServer != null) {
-    await SyncTvService.syncServerTime();
-  }
-  const oauth2Callbacks = FlutterWebAuth2CallbackClient();
   final p2pMediaPreferences = P2pMediaPreferencesController(
     store: const SharedPreferencesP2pMediaPreferencesStore(),
   );
-  await p2pMediaPreferences.load();
   final playbackModePreferences = PlaybackModePreferencesController(
     store: const SharedPreferencesPlaybackModeStore(),
   );
-  await playbackModePreferences.load();
   final playerVolumePreferences = PlayerVolumePreferencesController(
     store: const SharedPreferencesPlayerVolumeStore(),
   );
-  await playerVolumePreferences.load();
   final playbackOverlayPreferences = PlaybackOverlayPreferencesController(
     store: const SharedPreferencesPlaybackOverlayStore(),
   );
-  await playbackOverlayPreferences.load();
   final realtimeEventLogPreferences = RealtimeEventLogPreferencesController(
     store: const SharedPreferencesRealtimeEventLogStore(),
   );
-  await realtimeEventLogPreferences.load();
+  await Future.wait([
+    appLocaleController.load(),
+    SyncTvService.init(),
+    p2pMediaPreferences.load(),
+    playbackModePreferences.load(),
+    playerVolumePreferences.load(),
+    playbackOverlayPreferences.load(),
+    realtimeEventLogPreferences.load(),
+    _configureDesktopWindow(),
+  ]);
+
+  const oauth2Callbacks = FlutterWebAuth2CallbackClient();
   final opaqueAuthenticator = OpaqueAuthenticatorService(
     gateway: const SyncTvOpaqueAuthGateway(),
   );
   const roomSessionGateway = SyncTvRoomSessionGateway();
 
-  if (!kIsWeb &&
-      const {
-        TargetPlatform.macOS,
-        TargetPlatform.windows,
-        TargetPlatform.linux,
-      }.contains(defaultTargetPlatform)) {
-    await windowManager.ensureInitialized();
-    await windowManager.setTitleBarStyle(
-      TitleBarStyle.normal,
-      windowButtonVisibility: true,
-    );
-    await windowManager.setMinimumSize(desktopWindowMinimumSize);
-    final windowSize = await windowManager.getSize();
-    if (windowSize.width < desktopWindowMinimumSize.width ||
-        windowSize.height < desktopWindowMinimumSize.height) {
-      await windowManager.setSize(desktopWindowDefaultSize);
-      await windowManager.center();
-    }
-  }
-
-  try {
-    SyncTvVideoPlayerMediaKit.ensureInitialized(
-      android: true,
-      iOS: false,
-      windows: true,
-      macOS: true,
-      linux: true,
-    );
-  } catch (e) {
-    debugPrint('Failed to initialize media playback: $e');
-  }
   final dependencies = AppDependencies(
     accountGateway: const SyncTvAccountGateway(),
     adminGateway: const SyncTvAdminGateway(),
@@ -152,6 +124,49 @@ void main(List<String> args) async {
     voiceChatSessionFactory: const NativeVoiceChatSessionFactory(),
   );
   runApp(MyApp(dependencies: dependencies));
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    _initializeDeferredRuntime();
+  });
+}
+
+Future<void> _configureDesktopWindow() async {
+  if (kIsWeb ||
+      !const {
+        TargetPlatform.macOS,
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      }.contains(defaultTargetPlatform)) {
+    return;
+  }
+  await windowManager.ensureInitialized();
+  await windowManager.setTitleBarStyle(
+    TitleBarStyle.normal,
+    windowButtonVisibility: true,
+  );
+  await windowManager.setMinimumSize(desktopWindowMinimumSize);
+  final windowSize = await windowManager.getSize();
+  if (windowSize.width < desktopWindowMinimumSize.width ||
+      windowSize.height < desktopWindowMinimumSize.height) {
+    await windowManager.setSize(desktopWindowDefaultSize);
+    await windowManager.center();
+  }
+}
+
+void _initializeDeferredRuntime() {
+  if (SyncTvService.activeServer != null) {
+    unawaited(SyncTvService.syncServerTime());
+  }
+  try {
+    SyncTvVideoPlayerMediaKit.ensureInitialized(
+      android: true,
+      iOS: false,
+      windows: true,
+      macOS: true,
+      linux: true,
+    );
+  } catch (error) {
+    debugPrint('Failed to initialize media playback: $error');
+  }
 }
 
 const _enableAccessibilityTools = bool.fromEnvironment(

--- a/test/data/synctv_api/synctv_session_store_test.dart
+++ b/test/data/synctv_api/synctv_session_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -6,6 +7,7 @@ import 'package:synctv_app/contracts/account_models.dart';
 import 'package:synctv_app/data/synctv_api/synctv_api_client.dart';
 import 'package:synctv_app/data/synctv_api/synctv_runtime_service.dart';
 import 'package:synctv_app/data/synctv_api/synctv_session_store.dart';
+import 'package:synctv_app/src/generated/proto/client.pb.dart' as client;
 
 SyncTvServerProfile _profile({
   required String id,
@@ -250,5 +252,76 @@ void main() {
     expect(restartedRuntime.activeServer?.allowInsecureTls, isTrue);
     expect(restartedRuntime.allowInsecureTls, isTrue);
     expect(restartedRuntime.api.allowInsecureTls, isTrue);
+  });
+
+  test('runtime init does not wait for a pending server probe', () async {
+    const endpoint = 'https://pending.example.com';
+    final pendingServer = SyncTvServerProfile(
+      endpoint: endpoint,
+      declaredServerId: '',
+      name: endpoint,
+    );
+    SharedPreferences.setMockInitialValues({
+      SyncTvSessionStore.serversKey: jsonEncode([pendingServer.toJson()]),
+      SyncTvSessionStore.activeServerKey: endpoint,
+    });
+    final probeStarted = Completer<void>();
+    final probeResponse = Completer<client.GetServerInfoResponse>();
+    final runtime = SyncTvRuntimeService(
+      serverInfoProbe: (_) {
+        probeStarted.complete();
+        return probeResponse.future;
+      },
+    );
+    addTearDown(runtime.api.close);
+
+    await runtime.init().timeout(const Duration(seconds: 1));
+
+    expect(runtime.activeServer?.endpoint, endpoint);
+    expect(probeStarted.isCompleted, isTrue);
+    expect(probeResponse.isCompleted, isFalse);
+    probeResponse.complete(client.GetServerInfoResponse());
+    await Future<void>.delayed(Duration.zero);
+  });
+
+  test('pending server probe cannot override a later selection', () async {
+    const pendingEndpoint = 'https://pending.example.com';
+    const selectedEndpoint = 'https://selected.example.com';
+    final pendingServer = SyncTvServerProfile(
+      endpoint: pendingEndpoint,
+      declaredServerId: '',
+      name: pendingEndpoint,
+    );
+    final selectedServer = _profile(id: 'selected', endpoint: selectedEndpoint);
+    SharedPreferences.setMockInitialValues({
+      SyncTvSessionStore.serversKey: jsonEncode([
+        pendingServer.toJson(),
+        selectedServer.toJson(),
+      ]),
+      SyncTvSessionStore.activeServerKey: pendingEndpoint,
+    });
+    final probeResponse = Completer<client.GetServerInfoResponse>();
+    final runtime = SyncTvRuntimeService(
+      serverInfoProbe: (_) => probeResponse.future,
+    );
+    addTearDown(runtime.api.close);
+
+    await runtime.init();
+    await runtime.activateServer(selectedEndpoint);
+    probeResponse.complete(
+      client.GetServerInfoResponse(
+        serverId: 'pending-id',
+        serverName: 'Pending server',
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(runtime.activeServer?.endpoint, selectedEndpoint);
+    expect(
+      runtime.servers
+          .singleWhere((server) => server.endpoint == pendingEndpoint)
+          .isPending,
+      isTrue,
+    );
   });
 }

--- a/test/features/account/presentation/account_center_page_test.dart
+++ b/test/features/account/presentation/account_center_page_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/contracts/synctv_models.dart';
+import 'package:synctv_app/core/network/resource_url_resolver.dart';
+import 'package:synctv_app/core/presentation/dependency_scope.dart';
+import 'package:synctv_app/core/presentation/widgets/app_form_controls.dart';
+import 'package:synctv_app/features/account/application/account_gateway.dart';
+import 'package:synctv_app/features/account/presentation/account_center_page.dart';
+import 'package:synctv_app/features/auth/application/native_apple_sign_in_client.dart';
+import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart';
+import 'package:synctv_app/features/auth/application/opaque_authenticator.dart';
+import 'package:synctv_app/features/auth/application/passkey_client.dart';
+import 'package:synctv_app/l10n/l10n.dart';
+import 'package:synctv_app/src/generated/proto/common.pbenum.dart'
+    as common_enum;
+
+import '../../../test_app.dart';
+
+void main() {
+  testWidgets('slow account modules do not block navigation or local actions', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final gateway = _HangingAccountGateway();
+    var createRoomCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        builder: (context, child) => DependencyRegistryScope(
+          values: {
+            AccountGateway: gateway,
+            OpaqueAuthenticatorService: OpaqueAuthenticatorService(
+              gateway: _UnusedOpaqueGateway(),
+            ),
+            OAuth2CallbackClient: _UnavailableOAuth2Callbacks(),
+            NativeAppleSignInClient: _UnavailableAppleSignIn(),
+            PasskeyClient: _UnavailablePasskeyClient(),
+            ResourceUrlResolver: const IdentityResourceUrlResolver(),
+          },
+          child: buildThemedTestApp(context, child),
+        ),
+        home: AccountCenterPage(
+          initialUser: SyncTvUser(
+            id: 'user-1',
+            username: 'Cached user',
+            role: const AccountUserRole(common_enum.UserRole.USER_ROLE_USER),
+          ),
+          onOpenRoom: (_) async {},
+          onCreateRoom: () async => createRoomCalls++,
+          onManageRoom: (_) async {},
+          onOpenProviderBinding: (_) async {},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Cached user'), findsWidgets);
+    expect(find.byType(AppLinearProgress), findsOneWidget);
+
+    await tester.tap(find.text('Rooms').first);
+    for (var frame = 0; frame < 5; frame++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    final createRoomButton = find.widgetWithText(
+      AppActionButton,
+      'Create room',
+    );
+    await tester.ensureVisible(createRoomButton);
+    await tester.pump();
+    await tester.tap(createRoomButton);
+    await tester.pump();
+
+    expect(createRoomCalls, 1);
+    expect(gateway.pending.isCompleted, isFalse);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+final class _HangingAccountGateway implements AccountGateway {
+  final Completer<Never> pending = Completer<Never>();
+
+  @override
+  String? get activeServerName => 'Slow server';
+
+  @override
+  String get serverBaseUrl => 'https://slow.example.test';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => pending.future;
+}
+
+final class _UnusedOpaqueGateway implements OpaqueAuthGateway {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+final class _UnavailableOAuth2Callbacks implements OAuth2CallbackClient {
+  @override
+  bool get canCreateSession => false;
+
+  @override
+  Future<OAuth2CallbackSession> createSession() =>
+      throw const OAuth2CallbackBindFailed();
+}
+
+final class _UnavailableAppleSignIn implements NativeAppleSignInClient {
+  @override
+  bool get isSupported => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+final class _UnavailablePasskeyClient implements PasskeyClient {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}

--- a/test/features/content_reports/presentation/content_reports_view_test.dart
+++ b/test/features/content_reports/presentation/content_reports_view_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/contracts/admin_models.dart';
+import 'package:synctv_app/core/presentation/widgets/app_form_controls.dart';
+import 'package:synctv_app/features/content_reports/application/content_reports_gateway.dart';
+import 'package:synctv_app/features/content_reports/presentation/content_reports_view.dart';
+import 'package:synctv_app/l10n/l10n.dart';
+import 'package:synctv_app/src/generated/proto/admin.pbenum.dart' as admin_enum;
+
+import '../../../test_app.dart';
+
+void main() {
+  testWidgets('latest report filter wins while existing results stay visible', (
+    tester,
+  ) async {
+    final gateway = _ControlledContentReportsGateway();
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        builder: buildThemedTestApp,
+        home: Scaffold(
+          body: ContentReportsView(
+            gateway: gateway,
+            showTargetTypeTabs: false,
+            initialTargetType: admin_enum
+                .ContentReportTargetType
+                .CONTENT_REPORT_TARGET_TYPE_ROOM,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Initial room'), findsOneWidget);
+
+    final search = find.byType(TextField);
+    await tester.enterText(search, 'old');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    expect(find.textContaining('Initial room'), findsOneWidget);
+    expect(find.byType(AppLinearProgress), findsOneWidget);
+
+    await tester.enterText(search, 'new');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    gateway.newRequest.complete(_page('New room'));
+    await tester.pump();
+    expect(find.textContaining('New room'), findsOneWidget);
+
+    gateway.oldRequest.complete(_page('Old room'));
+    await tester.pump();
+    expect(find.textContaining('New room'), findsOneWidget);
+    expect(find.textContaining('Old room'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+AdminContentReportsPage _page(String roomName) => AdminContentReportsPage(
+  reports: [_report(roomName)],
+  total: 1,
+  page: 1,
+  pageSize: 50,
+);
+
+AdminContentReport _report(String roomName) => AdminContentReport(
+  id: roomName,
+  reporterUserId: 'reporter',
+  reporterUsername: 'Reporter',
+  roomId: '',
+  roomName: '',
+  targetType:
+      admin_enum.ContentReportTargetType.CONTENT_REPORT_TARGET_TYPE_ROOM,
+  targetRoomId: roomName,
+  targetRoomName: roomName,
+  targetUserId: '',
+  targetUsername: '',
+  targetMemberRoomId: '',
+  targetMemberRoomName: '',
+  targetMemberUserId: '',
+  targetMemberUsername: '',
+  targetChatMessageId: 0,
+  targetChatMessageCreatedAt: 0,
+  targetChatMessagePreview: '',
+  reasonCode: 'test',
+  reason: 'Test report',
+  metadata: const {},
+  status: admin_enum.ContentReportStatus.CONTENT_REPORT_STATUS_OPEN,
+  reviewedBy: '',
+  reviewedByUsername: '',
+  reviewedAt: 0,
+  resolutionNote: '',
+  createdAt: 0,
+  updatedAt: 0,
+);
+
+final class _ControlledContentReportsGateway implements ContentReportsGateway {
+  final oldRequest = Completer<AdminContentReportsPage>();
+  final newRequest = Completer<AdminContentReportsPage>();
+
+  @override
+  Future<AdminContentReportsPage> list(ContentReportsQuery query) {
+    return switch (query.search) {
+      'old' => oldRequest.future,
+      'new' => newRequest.future,
+      _ => Future.value(_page('Initial room')),
+    };
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}

--- a/test/features/home/home_view_test.dart
+++ b/test/features/home/home_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/core/presentation/widgets/app_form_controls.dart';
 import 'package:synctv_app/features/home/showcase/home_showcase.dart';
 import 'package:synctv_app/features/home/presentation/home_view.dart';
 import 'package:synctv_app/contracts/synctv_models.dart';
@@ -86,6 +87,37 @@ void main() {
     expect(find.text('Featured rooms'), findsOneWidget);
     expect(find.text('Popular rooms'), findsNothing);
     expect(find.text('No rooms match the current filters'), findsNothing);
+  });
+
+  testWidgets('loading keeps discovery controls and server switching usable', (
+    tester,
+  ) async {
+    await setViewport(tester, const Size(390, 844));
+    var openServerCalls = 0;
+    await tester.pumpWidget(
+      HomeShowcaseApp(
+        state: homeShowcaseState(
+          rooms: const [],
+          featuredRooms: const [],
+          isLoading: true,
+        ),
+        callbacks: homeShowcaseCallbacks(
+          onOpenServerSettings: () => openServerCalls++,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(AppLinearProgress), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    final serverButton = find.widgetWithText(AppActionButton, 'Server');
+    expect(serverButton, findsOneWidget);
+
+    await tester.ensureVisible(serverButton);
+    await tester.pump();
+    await tester.tap(serverButton);
+    expect(openServerCalls, 1);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('room created by the current user has an ownership badge', (

--- a/test/features/media_library/presentation/add_media_dialog_prepare_test.dart
+++ b/test/features/media_library/presentation/add_media_dialog_prepare_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:fixnum/fixnum.dart';
@@ -9,6 +10,7 @@ import 'package:synctv_app/contracts/public_models.dart';
 import 'package:synctv_app/contracts/room_management_models.dart';
 import 'package:synctv_app/contracts/room_media_models.dart';
 import 'package:synctv_app/core/presentation/dependency_scope.dart';
+import 'package:synctv_app/core/presentation/widgets/app_form_controls.dart';
 import 'package:synctv_app/features/media_library/presentation/add_media_dialog.dart';
 import 'package:synctv_app/features/providers/application/provider_gateway.dart';
 import 'package:synctv_app/l10n/l10n.dart';
@@ -25,6 +27,47 @@ import 'package:synctv_app/src/generated/proto/source_config.pbenum.dart'
 import '../../../test_app.dart';
 
 void main() {
+  testWidgets('slow provider does not block another media source', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const ui.Size(1300, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final gateway = _PartiallyHangingGateway();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        builder: (context, child) => buildThemedTestApp(
+          context,
+          DependencyScope<ProviderGateway>(value: gateway, child: child!),
+        ),
+        home: const Scaffold(
+          body: AddMediaDialog(roomId: 'room_nonblocking_test'),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.enterText(
+      find.byType(TextField).at(1),
+      'https://media.example.test/video.mp4',
+    );
+    expect(find.byKey(const Key('direct-url-preview')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('add-media-source-tile-4')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Directory password'), findsOneWidget);
+    expect(find.text('No files'), findsOneWidget);
+    expect(find.byType(AppLinearProgress), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('direct links require prepare and support partial selection', (
     tester,
   ) async {
@@ -612,6 +655,42 @@ class _PrepareGateway implements ProviderGateway {
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName}');
+}
+
+class _PartiallyHangingGateway extends _PrepareGateway {
+  final Completer<List<EmbyBindInfo>> _embyBinds = Completer();
+
+  @override
+  Future<List<AlistBindInfo>> getAllAlistBindInfos() async => const [
+    AlistBindInfo(
+      id: 'alist-bind',
+      serverId: 'alist-server',
+      host: 'https://alist.example.test',
+      username: 'tester',
+      createdAt: 1,
+      providerInstanceName: '',
+    ),
+  ];
+
+  @override
+  Future<List<EmbyBindInfo>> getAllEmbyBindInfos() => _embyBinds.future;
+
+  @override
+  Future<AlistListPage> listAlistPage(
+    String path, {
+    String? keyword,
+    int page = 1,
+    int max = 20,
+    String password = '',
+    String serverId = '',
+    String instanceName = '',
+  }) async => AlistListPage(
+    serverId: serverId,
+    providerInstanceName: instanceName,
+    items: const [],
+    total: 0,
+    source: null,
+  );
 }
 
 class _BilibiliPolicyGateway extends _PrepareGateway {

--- a/test/features/server_settings/server_settings_dialog_test.dart
+++ b/test/features/server_settings/server_settings_dialog_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:synctv_app/l10n/l10n.dart';
@@ -163,6 +165,77 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('slow server metadata does not block repeated server switches', (
+    tester,
+  ) async {
+    final gateway = _SlowMetadataServerConnectionGateway();
+    var serverChangedCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          ...AppLocalizations.localizationsDelegates,
+        ],
+        builder: (context, child) => DependencyScope<ServerConnectionGateway>(
+          value: gateway,
+          child: buildThemedTestApp(context, child),
+        ),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => showServerSettingsDialog(
+                context: context,
+                onServerChanged: () => serverChangedCalls++,
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    await tester.pump();
+    expect(gateway.activeServer.name, 'Second server');
+    expect(serverChangedCalls, 1);
+    expect(
+      tester
+          .widget<AppActionButton>(
+            find.widgetWithText(AppActionButton, 'Add server'),
+          )
+          .onPressed,
+      isNotNull,
+    );
+    expect(
+      tester
+          .widget<AppIconButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.login_rounded),
+              matching: find.byType(AppIconButton),
+            ),
+          )
+          .onPressed,
+      isNotNull,
+    );
+
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    await tester.pump();
+    expect(gateway.activeServer.name, 'First server');
+    expect(serverChangedCalls, 2);
+
+    gateway.completeBackgroundRequests();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    await tester.tap(find.widgetWithText(AppActionButton, 'Done'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('server list and add dialog stay distinct at mobile width', (
     tester,
   ) async {
@@ -290,4 +363,66 @@ final class _EmptyServerConnectionGateway implements ServerConnectionGateway {
 
   @override
   Future<void> syncServerTime({bool refresh = false}) async {}
+}
+
+final class _SlowMetadataServerConnectionGateway
+    implements ServerConnectionGateway {
+  static const _first = ServerConnectionProfile(
+    endpoint: 'https://first.example.test',
+    declaredServerId: 'first',
+    name: 'First server',
+    isBuiltIn: false,
+    allowInsecureTls: false,
+  );
+  static const _second = ServerConnectionProfile(
+    endpoint: 'https://second.example.test',
+    declaredServerId: 'second',
+    name: 'Second server',
+    isBuiltIn: false,
+    allowInsecureTls: false,
+  );
+
+  final Completer<ServerInfo> _serverInfo = Completer<ServerInfo>();
+  final Completer<void> _serverTime = Completer<void>();
+  ServerConnectionProfile _activeServer = _first;
+
+  @override
+  ServerConnectionProfile get activeServer => _activeServer;
+
+  @override
+  String get serverBaseUrl => _activeServer.endpoint;
+
+  @override
+  List<ServerConnectionProfile> get servers => const [_first, _second];
+
+  @override
+  Future<ServerConnectionProfile> addServer(
+    String address, {
+    bool allowInsecureTls = false,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> activateServer(String endpoint) async {
+    _activeServer = servers.firstWhere((server) => server.endpoint == endpoint);
+  }
+
+  @override
+  Future<ServerInfo> getServerInfo({bool refresh = false}) =>
+      _serverInfo.future;
+
+  @override
+  Future<void> removeServer(String endpoint) async {}
+
+  @override
+  Future<void> syncServerTime({bool refresh = false}) => _serverTime.future;
+
+  void completeBackgroundRequests() {
+    _serverInfo.complete(
+      ServerInfo(
+        serverId: _activeServer.declaredServerId,
+        serverName: _activeServer.name,
+      ),
+    );
+    _serverTime.complete();
+  }
 }


### PR DESCRIPTION
## Summary

- render the app shell immediately while persisted server sessions restore and remote server probes continue in the background
- keep server selection and add-server controls responsive when the active or built-in server is slow or unavailable
- preserve home and account snapshots while independent sections refresh without full-page loading states
- isolate media-provider binding and instance requests so one slow provider cannot block direct URLs or another ready provider
- prevent stale server, account, report-filter, and provider responses from overwriting newer state

## Verification

- `flutter analyze`
- `flutter test`: 869 passed
- focused slow-request, stale-response, server-settings, home, account, reports, and media-provider widget tests
- `git diff --check`
- real Rust backend and macOS client startup against `http://127.0.0.1:8080`
- verified home rendering, server selection, add-server form, and account center while the backend was running