### PR TITLE
fix(web): harden OAuth and playback lifecycle

### DIFF
--- a/lib/features/account/presentation/account_center_page.dart
+++ b/lib/features/account/presentation/account_center_page.dart
@@ -1138,17 +1138,17 @@ class _AccountCenterPageState extends State<AccountCenterPage>
         bindAttempt <= oauth2CallbackBindMaxAttempts;
         bindAttempt++
       ) {
-        final verificationId = await _verifySensitiveOperation();
-        if (verificationId == null) {
-          if (mounted && _bindProvider != null) {
-            setState(() => _bindProvider = null);
-          }
-          return;
-        }
         try {
           await withOAuth2CallbackSession(oauth2Callbacks, (
             callbackSession,
           ) async {
+            final verificationId = await _verifySensitiveOperation();
+            if (verificationId == null) {
+              if (mounted && _bindProvider != null) {
+                setState(() => _bindProvider = null);
+              }
+              return;
+            }
             final start = await _gateway.startOAuth2Bind(
               provider.name,
               redirectUrl: callbackSession.redirectUrl,

--- a/lib/features/auth/application/oauth2_callback_client.dart
+++ b/lib/features/auth/application/oauth2_callback_client.dart
@@ -4,6 +4,12 @@ abstract interface class OAuth2CallbackDispatcher {
   void dispatch();
 }
 
+const oauth2WebCallbackMessageKey = 'flutter-web-auth-2';
+const _oauth2WebCallbackStoragePrefix = 'synctv-oauth2-callback:';
+
+String oauth2WebCallbackStorageKey(String state) =>
+    '$_oauth2WebCallbackStoragePrefix$state';
+
 abstract interface class OAuth2CallbackClient {
   bool get canCreateSession;
 
@@ -54,6 +60,14 @@ final class OAuth2AuthorizationCanceled implements Exception {
 
 final class OAuth2AuthorizationTimedOut implements Exception {
   const OAuth2AuthorizationTimedOut();
+}
+
+final class OAuth2AuthorizationWindowBlocked implements Exception {
+  const OAuth2AuthorizationWindowBlocked();
+
+  @override
+  String toString() =>
+      'The browser blocked the OAuth2 authorization window. Allow pop-ups and try again.';
 }
 
 final class OAuth2CallbackBindFailed implements Exception {

--- a/lib/features/auth/infrastructure/oauth2_callback_dispatcher_web.dart
+++ b/lib/features/auth/infrastructure/oauth2_callback_dispatcher_web.dart
@@ -3,8 +3,6 @@ import 'dart:js_interop';
 import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart';
 import 'package:web/web.dart' as web;
 
-const _storageKey = 'flutter-web-auth-2';
-
 final class PlatformOAuth2CallbackDispatcher
     implements OAuth2CallbackDispatcher {
   const PlatformOAuth2CallbackDispatcher();
@@ -12,7 +10,8 @@ final class PlatformOAuth2CallbackDispatcher
   @override
   void dispatch() {
     final callbackUrl = web.window.location.href;
-    final message = {_storageKey: callbackUrl}.jsify();
+    final state = Uri.tryParse(callbackUrl)?.queryParameters['state'];
+    final message = {oauth2WebCallbackMessageKey: callbackUrl}.jsify();
     final targetOrigin = web.window.location.origin.toJS;
     final opener = web.window.openerCrossOrigin;
 
@@ -30,7 +29,13 @@ final class PlatformOAuth2CallbackDispatcher
       return;
     }
 
-    web.window.localStorage.setItem(_storageKey, callbackUrl);
+    web.window.localStorage.setItem(oauth2WebCallbackMessageKey, callbackUrl);
+    if (state != null && state.isNotEmpty) {
+      web.window.localStorage.setItem(
+        oauth2WebCallbackStorageKey(state),
+        callbackUrl,
+      );
+    }
     web.window.close();
   }
 }

--- a/lib/features/auth/infrastructure/oauth2_callback_service.dart
+++ b/lib/features/auth/infrastructure/oauth2_callback_service.dart
@@ -9,6 +9,7 @@ import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart
 import 'package:synctv_app/features/auth/application/native_apple_sign_in_client.dart';
 import 'package:synctv_app/features/auth/domain/oauth2_callback_config.dart';
 import 'package:synctv_app/features/auth/domain/oauth2_callback_parser.dart';
+import 'package:synctv_app/features/auth/infrastructure/oauth2_web_callback_session.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_to_front/window_to_front.dart';
 
@@ -56,10 +57,9 @@ class OAuth2CallbackService {
         );
       }
       final redirectUri = webRedirectUri(Uri.base);
-      return _FlutterWebAuth2CallbackSession(
+      return createOAuth2WebCallbackSession(
         redirectUri: redirectUri,
-        callbackUrlScheme: redirectUri.scheme,
-        options: optionsFor(redirectUri),
+        authorizationTimeout: authorizationTimeout,
       );
     }
 

--- a/lib/features/auth/infrastructure/oauth2_web_callback_session.dart
+++ b/lib/features/auth/infrastructure/oauth2_web_callback_session.dart
@@ -1,0 +1,2 @@
+export 'oauth2_web_callback_session_stub.dart'
+    if (dart.library.js_interop) 'oauth2_web_callback_session_web.dart';

--- a/lib/features/auth/infrastructure/oauth2_web_callback_session_stub.dart
+++ b/lib/features/auth/infrastructure/oauth2_web_callback_session_stub.dart
@@ -1,0 +1,6 @@
+import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart';
+
+OAuth2CallbackSession createOAuth2WebCallbackSession({
+  required Uri redirectUri,
+  required Duration authorizationTimeout,
+}) => throw UnsupportedError('Web OAuth2 is unavailable on this platform.');

--- a/lib/features/auth/infrastructure/oauth2_web_callback_session_web.dart
+++ b/lib/features/auth/infrastructure/oauth2_web_callback_session_web.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:synctv_app/contracts/account_models.dart';
+import 'package:synctv_app/features/auth/application/oauth2_callback_client.dart';
+import 'package:synctv_app/features/auth/domain/oauth2_callback_parser.dart';
+import 'package:web/web.dart' as web;
+
+const _popupFeatures = 'popup=yes,width=520,height=720';
+const _closedWindowPollInterval = Duration(milliseconds: 250);
+
+OAuth2CallbackSession createOAuth2WebCallbackSession({
+  required Uri redirectUri,
+  required Duration authorizationTimeout,
+}) {
+  final popup = web.window.open('about:blank', '_blank', _popupFeatures);
+  if (popup == null) throw const OAuth2AuthorizationWindowBlocked();
+
+  // The callback can use same-origin storage when the provider cannot access
+  // its opener. Retain the WindowProxy so this page can still navigate it.
+  popup.opener = null;
+  popup.blur();
+  web.window.focus();
+  return _WebOAuth2CallbackSession(
+    popup,
+    redirectUri: redirectUri,
+    authorizationTimeout: authorizationTimeout,
+  );
+}
+
+final class _WebOAuth2CallbackSession implements OAuth2CallbackSession {
+  _WebOAuth2CallbackSession(
+    this._popup, {
+    required this.redirectUri,
+    required this.authorizationTimeout,
+  });
+
+  final web.Window _popup;
+  final Uri redirectUri;
+  final Duration authorizationTimeout;
+
+  StreamSubscription<web.MessageEvent>? _messageSubscription;
+  StreamSubscription<web.StorageEvent>? _storageSubscription;
+  Timer? _pollTimer;
+  Timer? _timeoutTimer;
+  Completer<String>? _pendingCallback;
+  bool _closed = false;
+
+  @override
+  String get redirectUrl => redirectUri.toString();
+
+  @override
+  Future<OAuth2CallbackPayload> authorize({
+    required Uri authorizationUrl,
+    required String expectedState,
+  }) async {
+    if (_closed || _popup.closed) {
+      throw const OAuth2AuthorizationCanceled();
+    }
+    if (_pendingCallback != null) {
+      throw StateError('This OAuth2 session is already authorizing.');
+    }
+
+    final storageKey = oauth2WebCallbackStorageKey(expectedState);
+    web.window.localStorage
+      ..removeItem(oauth2WebCallbackMessageKey)
+      ..removeItem(storageKey);
+    final callback = Completer<String>();
+    _pendingCallback = callback;
+
+    void complete(String callbackUrl) {
+      if (!callback.isCompleted) callback.complete(callbackUrl);
+    }
+
+    _messageSubscription = web.window.onMessage.listen((event) {
+      if (event.origin != redirectUri.origin) return;
+      final data = event.data.dartify();
+      final callbackUrl = data is Map
+          ? data[oauth2WebCallbackMessageKey]
+          : null;
+      if (callbackUrl is String) complete(callbackUrl);
+    });
+    _storageSubscription = web.EventStreamProviders.storageEvent
+        .forTarget(web.window)
+        .listen((event) {
+          if (event.key != storageKey) return;
+          final value = event.newValue;
+          if (value != null) complete(value);
+        });
+    _pollTimer = Timer.periodic(_closedWindowPollInterval, (_) {
+      final callbackUrl = web.window.localStorage.getItem(storageKey);
+      if (callbackUrl != null) {
+        complete(callbackUrl);
+      } else if (_popup.closed && !callback.isCompleted) {
+        callback.completeError(const OAuth2AuthorizationCanceled());
+      }
+    });
+    _timeoutTimer = Timer(authorizationTimeout, () {
+      if (!callback.isCompleted) {
+        callback.completeError(const OAuth2AuthorizationTimedOut());
+      }
+    });
+
+    try {
+      _popup.focus();
+      _popup.location.href = authorizationUrl.toString();
+      final callbackUrl = await callback.future;
+      return OAuth2CallbackParser.parse(
+        Uri.parse(callbackUrl),
+        expectedState: expectedState,
+        expectedRedirectUri: redirectUri,
+      );
+    } finally {
+      await _clearListeners();
+      _pendingCallback = null;
+      web.window.localStorage
+        ..removeItem(oauth2WebCallbackMessageKey)
+        ..removeItem(storageKey);
+    }
+  }
+
+  Future<void> _clearListeners() async {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    _timeoutTimer?.cancel();
+    _timeoutTimer = null;
+    await _messageSubscription?.cancel();
+    _messageSubscription = null;
+    await _storageSubscription?.cancel();
+    _storageSubscription = null;
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    final callback = _pendingCallback;
+    if (callback != null && !callback.isCompleted) {
+      callback.completeError(const OAuth2AuthorizationCanceled());
+    }
+    await _clearListeners();
+    if (!_popup.closed) _popup.close();
+  }
+}

--- a/packages/synctv_video_player_media_kit/lib/src/web_video_player_runtime.dart
+++ b/packages/synctv_video_player_media_kit/lib/src/web_video_player_runtime.dart
@@ -92,6 +92,7 @@ class WebVideoPlayerRuntime
   bool _initialized = false;
   bool _buffering = false;
   bool _disposed = false;
+  int _mediaGeneration = 0;
   Timer? _initializationTimeoutTimer;
   web.EventHandler? _onContextMenu;
   web.EventHandler? _onEnterPictureInPicture;
@@ -120,6 +121,9 @@ class WebVideoPlayerRuntime
       browserPictureInPictureAvailable &&
       web.document.pictureInPictureElement == _video;
 
+  @visibleForTesting
+  bool get hasActiveEngineForTesting => _engine != null;
+
   @override
   Duration get position => Duration(
     milliseconds: (_video.currentTime * Duration.millisecondsPerSecond).round(),
@@ -136,7 +140,9 @@ class WebVideoPlayerRuntime
       );
     }
 
+    final generation = ++_mediaGeneration;
     await _resetMedia();
+    if (!_isCurrentMediaGeneration(generation)) return;
     final resolvedUri = _resolveMediaUri(media.uri);
     final uri = Uri.parse(resolvedUri);
     final transport = detectWebPlaybackTransport(
@@ -153,24 +159,31 @@ class WebVideoPlayerRuntime
       case WebPlaybackEngine.progressive || WebPlaybackEngine.nativeHls:
         _openNative(resolvedUri);
       case WebPlaybackEngine.hlsJs:
-        await _openHls(resolvedUri);
-        _scheduleInitializationTimeout();
+        if (await _openHls(resolvedUri, generation)) {
+          _scheduleInitializationTimeout();
+        }
       case WebPlaybackEngine.dashJs:
-        await _openDash(resolvedUri);
-        _scheduleInitializationTimeout();
+        if (await _openDash(resolvedUri, generation)) {
+          _scheduleInitializationTimeout();
+        }
       case WebPlaybackEngine.mpegTsJs:
-        await _openMpegTs(resolvedUri, transport);
-        _scheduleInitializationTimeout();
+        if (await _openMpegTs(resolvedUri, transport, generation)) {
+          _scheduleInitializationTimeout();
+        }
     }
   }
+
+  bool _isCurrentMediaGeneration(int generation) =>
+      !_disposed && generation == _mediaGeneration;
 
   void _openNative(String uri) {
     _video.src = uri;
     _video.load();
   }
 
-  Future<void> _openHls(String uri) async {
+  Future<bool> _openHls(String uri, int generation) async {
     final constructor = await _WebEngineLoader.load(_hlsBundle) as JSFunction;
+    if (!_isCurrentMediaGeneration(generation)) return false;
     final supported = constructor.callMethod<JSBoolean>('isSupported'.toJS);
     if (!supported.toDart) {
       throw PlatformException(
@@ -212,10 +225,12 @@ class WebVideoPlayerRuntime
     });
     hls.callMethod<JSAny?>('loadSource'.toJS, uri.toJS);
     hls.callMethod<JSAny?>('attachMedia'.toJS, _video);
+    return true;
   }
 
-  Future<void> _openDash(String uri) async {
+  Future<bool> _openDash(String uri, int generation) async {
     final dashjs = await _WebEngineLoader.load(_dashBundle);
+    if (!_isCurrentMediaGeneration(generation)) return false;
     final mediaPlayerFactory = dashjs.getProperty<JSFunction>(
       'MediaPlayer'.toJS,
     );
@@ -242,10 +257,16 @@ class WebVideoPlayerRuntime
       singleArgument: true,
     );
     player.callMethod<JSAny?>('initialize'.toJS, _video, uri.toJS, false.toJS);
+    return true;
   }
 
-  Future<void> _openMpegTs(String uri, WebPlaybackTransport transport) async {
+  Future<bool> _openMpegTs(
+    String uri,
+    WebPlaybackTransport transport,
+    int generation,
+  ) async {
     final mpegts = await _WebEngineLoader.load(_mpegTsBundle);
+    if (!_isCurrentMediaGeneration(generation)) return false;
     final supported = mpegts.callMethod<JSBoolean>('isSupported'.toJS);
     if (!supported.toDart) {
       throw PlatformException(
@@ -279,6 +300,7 @@ class WebVideoPlayerRuntime
     }
     player.callMethod<JSAny?>('attachMediaElement'.toJS, _video);
     player.callMethod<JSAny?>('load'.toJS);
+    return true;
   }
 
   void _bindEngineError(
@@ -780,9 +802,17 @@ class WebVideoPlayerRuntime
   @override
   Future<void> dispose() async {
     if (_disposed) return;
-    await exitPictureInPicture();
-    await _resetMedia();
+    final shouldExitPictureInPicture = _isPictureInPictureActive;
     _disposed = true;
+    _mediaGeneration++;
+    if (shouldExitPictureInPicture) {
+      try {
+        await web.document.exitPictureInPicture().toDart;
+      } on Object {
+        // Continue releasing the player when the browser rejects PiP exit.
+      }
+    }
+    await _resetMedia();
     _resetWebOptions();
     if (_onEnterPictureInPicture != null) {
       _video.removeEventListener(

--- a/test/features/account/presentation/account_center_page_test.dart
+++ b/test/features/account/presentation/account_center_page_test.dart
@@ -89,8 +89,9 @@ void main() {
   ) async {
     await tester.binding.setSurfaceSize(const Size(1200, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    final gateway = _OAuth2BindingAccountGateway();
-    final callbacks = _OAuth2Callbacks();
+    final events = <String>[];
+    final gateway = _OAuth2BindingAccountGateway(events);
+    final callbacks = _OAuth2Callbacks(events);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -144,6 +145,7 @@ void main() {
     expect(gateway.finishedState, 'bind-state');
     expect(callbacks.session.expectedState, 'bind-state');
     expect(callbacks.session.closeCount, 1);
+    expect(events, containsAllInOrder(['session', 'verification', 'start']));
     expect(tester.takeException(), isNull);
     await tester.pump(const Duration(seconds: 4));
   });
@@ -169,6 +171,9 @@ class _HangingAccountGateway implements AccountGateway {
 }
 
 final class _OAuth2BindingAccountGateway extends _HangingAccountGateway {
+  _OAuth2BindingAccountGateway(this.events);
+
+  final List<String> events;
   String? redirectUrl;
   String? finishedCode;
   String? finishedState;
@@ -208,10 +213,12 @@ final class _OAuth2BindingAccountGateway extends _HangingAccountGateway {
 
   @override
   Future<SensitiveOperationVerificationInfo>
-  startSensitiveOperationVerification() async =>
-      const SensitiveOperationVerificationComplete(
-        verificationId: 'verification-id',
-      );
+  startSensitiveOperationVerification() async {
+    events.add('verification');
+    return const SensitiveOperationVerificationComplete(
+      verificationId: 'verification-id',
+    );
+  }
 
   @override
   Future<OAuth2AuthorizationStart> startOAuth2Bind(
@@ -220,6 +227,7 @@ final class _OAuth2BindingAccountGateway extends _HangingAccountGateway {
     required String verificationId,
     bool native = false,
   }) async {
+    events.add('start');
     this.redirectUrl = redirectUrl;
     return const OAuth2AuthorizationStart(
       provider: 'github',
@@ -240,13 +248,19 @@ final class _OAuth2BindingAccountGateway extends _HangingAccountGateway {
 }
 
 final class _OAuth2Callbacks implements OAuth2CallbackClient {
+  _OAuth2Callbacks(this.events);
+
+  final List<String> events;
   final session = _OAuth2CallbackSession();
 
   @override
   bool get canCreateSession => true;
 
   @override
-  Future<OAuth2CallbackSession> createSession() async => session;
+  Future<OAuth2CallbackSession> createSession() async {
+    events.add('session');
+    return session;
+  }
 }
 
 final class _OAuth2CallbackSession implements OAuth2CallbackSession {

--- a/test/features/auth/presentation/auth_panel_test.dart
+++ b/test/features/auth/presentation/auth_panel_test.dart
@@ -21,8 +21,9 @@ void main() {
   ) async {
     await tester.binding.setSurfaceSize(const Size(1200, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    final gateway = _OAuth2AuthGateway();
-    final callbacks = _OAuth2Callbacks();
+    final events = <String>[];
+    final gateway = _OAuth2AuthGateway(events);
+    final callbacks = _OAuth2Callbacks(events);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -74,10 +75,14 @@ void main() {
     expect(gateway.finishedState, 'oauth-state');
     expect(callbacks.session.expectedState, 'oauth-state');
     expect(callbacks.session.closeCount, 1);
+    expect(events, containsAllInOrder(['session', 'start']));
   });
 }
 
 final class _OAuth2AuthGateway implements AuthGateway {
+  _OAuth2AuthGateway(this.events);
+
+  final List<String> events;
   String? redirectUrl;
   String? finishedCode;
   String? finishedState;
@@ -132,6 +137,7 @@ final class _OAuth2AuthGateway implements AuthGateway {
     String? redirectUrl,
     bool native = false,
   }) async {
+    events.add('start');
     this.redirectUrl = redirectUrl;
     return const OAuth2AuthorizationStart(
       provider: 'github',
@@ -163,13 +169,19 @@ final class _OAuth2AuthGateway implements AuthGateway {
 }
 
 final class _OAuth2Callbacks implements OAuth2CallbackClient {
+  _OAuth2Callbacks(this.events);
+
+  final List<String> events;
   final session = _OAuth2CallbackSession();
 
   @override
   bool get canCreateSession => true;
 
   @override
-  Future<OAuth2CallbackSession> createSession() async => session;
+  Future<OAuth2CallbackSession> createSession() async {
+    events.add('session');
+    return session;
+  }
 }
 
 final class _OAuth2CallbackSession implements OAuth2CallbackSession {

--- a/test/features/media_playback/web_video_runtime_direct_test.dart
+++ b/test/features/media_playback/web_video_runtime_direct_test.dart
@@ -12,6 +12,24 @@ import 'package:web/web.dart' as web;
 const _baseUrl = String.fromEnvironment('SYNCTV_WEB_MEDIA_TEST_BASE');
 
 void main() {
+  test('dispose invalidates a pending adaptive media open', () async {
+    final runtime = WebVideoPlayerRuntime(9901);
+    final events = runtime.events.listen((_) {});
+    addTearDown(events.cancel);
+    final opening = runtime.open(
+      Media(
+        'https://media.example.test/live/master.m3u8',
+        extras: const {'formatHint': 'hls'},
+      ),
+    );
+
+    await runtime.dispose();
+    await opening.timeout(const Duration(seconds: 1));
+
+    expect(runtime.hasActiveEngineForTesting, isFalse);
+    expect(web.document.getElementById('synctv-video-element-9901'), isNull);
+  });
+
   test('DASH runtime setup', () async {
     final runtime = WebVideoPlayerRuntime(9902);
     final errors = <Object>[];

--- a/web/synctv_service_worker.js
+++ b/web/synctv_service_worker.js
@@ -4,6 +4,7 @@ const APP_CACHE = 'synctv-app-runtime-v3';
 const P2P_PREFIX = '/__synctv_p2p__/';
 const P2P_HEADER_TIMEOUT_MS = 35000;
 const STATIC_PREFIXES = ['/assets/', '/canvaskit/', '/icons/', '/playback/'];
+const VERSIONED_STATIC_PREFIXES = ['/playback/'];
 const STATIC_PATHS = new Set([
   '/favicon.png',
   '/flutter.js',
@@ -44,7 +45,9 @@ self.addEventListener('fetch', (event) => {
     return;
   }
   if (isStaticAssetPath(url.pathname)) {
-    event.respondWith(cacheFirstStaticAsset(event));
+    event.respondWith(isVersionedStaticAssetPath(url.pathname)
+      ? cacheFirstStaticAsset(event)
+      : networkFirstStaticAsset(event));
   }
 });
 
@@ -61,6 +64,10 @@ function isAppNavigationPath(path) {
 function isStaticAssetPath(path) {
   return STATIC_PATHS.has(path) ||
     STATIC_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function isVersionedStaticAssetPath(path) {
+  return VERSIONED_STATIC_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
 function isCacheable(response) {
@@ -98,6 +105,21 @@ async function cacheFirstStaticAsset(event) {
     return cached;
   }
   return update;
+}
+
+async function networkFirstStaticAsset(event) {
+  const cache = await caches.open(APP_CACHE);
+  try {
+    const response = await fetch(event.request);
+    if (isCacheable(response)) {
+      event.waitUntil(cache.put(event.request, response.clone()).catch(() => {}));
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(event.request);
+    if (cached) return cached;
+    throw error;
+  }
 }
 
 async function handleP2pFetch(event) {


### PR DESCRIPTION
## Summary

- pre-open the browser OAuth window during the user gesture and recover callbacks through state-scoped same-origin storage when the opener is unavailable
- create account-binding callback sessions before asynchronous verification so browser popup policies do not block authorization
- invalidate pending adaptive media opens during source replacement and disposal
- refresh unversioned application assets from the network while retaining cache-first behavior for versioned playback libraries

## Validation

- `dart analyze --fatal-infos`
- `dart fix --dry-run`
- `dart format --output=none --set-exit-if-changed lib test tool packages`
- `flutter test` (894 passed)
- affected OAuth and account tests (30 passed)
- `flutter test --platform chrome test/features/media_playback/web_video_runtime_direct_test.dart`
- `flutter build web --release --no-web-resources-cdn --no-wasm-dry-run`
- localization and protobuf generation consistency checks
- `node --check web/synctv_service_worker.js`
- `git diff --check`