### PR TITLE
test(playback): cover seek precision across native and web

### DIFF
--- a/test/features/room/presentation/widgets/custom_video_player_interaction_test.dart
+++ b/test/features/room/presentation/widgets/custom_video_player_interaction_test.dart
@@ -554,6 +554,60 @@ void main() {
     },
   );
 
+  testWidgets('progress slider seeks and reports the same millisecond target', (
+    tester,
+  ) async {
+    final controller = _RecordingVideoPlayerController(
+      const VideoPlayerValue(
+        duration: Duration(seconds: 100),
+        position: Duration(seconds: 10),
+        isInitialized: true,
+        size: Size(1920, 1080),
+      ),
+    );
+    addTearDown(controller.dispose);
+    final reportedSeeks = <Duration>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: buildThemedTestApp,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 500,
+            child: CustomVideoPlayer(
+              volumePreferences: _volumePreferences(),
+              subtitleSource: const _EmptySubtitleSource(),
+              controller: controller,
+              title: 'Video',
+              interactionMode: VideoPlayerInteractionMode.desktop,
+              onUserSeek: reportedSeeks.add,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final slider = tester.widget<Slider>(
+      find.descendant(
+        of: find.byKey(const Key('playback_progress_slider')),
+        matching: find.byType(Slider),
+      ),
+    );
+    const targetMilliseconds = 73250.0;
+    slider.onChangeStart!(targetMilliseconds);
+    slider.onChanged!(targetMilliseconds);
+    slider.onChangeEnd!(targetMilliseconds);
+    await tester.pump();
+
+    const target = Duration(milliseconds: 73250);
+    expect(controller.seekPositions, [target]);
+    expect(reportedSeeks, [target]);
+  });
+
   testWidgets('live playback hides playback speed control', (tester) async {
     final controller = VideoPlayerController.networkUrl(
       Uri.parse('https://example.com/live.m3u8'),

--- a/test/packages/synctv_video_player_media_kit/web_video_player_runtime_test.dart
+++ b/test/packages/synctv_video_player_media_kit/web_video_player_runtime_test.dart
@@ -1,0 +1,23 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_video_player_media_kit/src/web_video_player_runtime.dart';
+
+void main() {
+  test(
+    'seekTo preserves millisecond precision in the HTML video element',
+    () async {
+      final runtime = WebVideoPlayerRuntime(73250);
+      final eventSubscription = runtime.events.listen((_) {});
+      addTearDown(() async {
+        await runtime.dispose();
+        await eventSubscription.cancel();
+      });
+
+      await runtime.seekTo(const Duration(milliseconds: 73250));
+
+      expect(runtime.position, const Duration(milliseconds: 73250));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- verify player controls forward the exact seek position to the controller and synchronization callback
- verify the web video runtime preserves millisecond seek precision in HTMLVideoElement
- cover the client side of synctv-org/synctv#437

## Validation

- playback widget tests (48 passed)
- video player package tests (16 passed)
- targeted Chrome seek tests
- flutter analyze
- verified seek behavior in the macOS app with Alist, Emby, and Bilibili providers