### PR TITLE
feat(emby): support passwordless account binding

### DIFF
--- a/lib/core/presentation/dialogs/app_dialogs.dart
+++ b/lib/core/presentation/dialogs/app_dialogs.dart
@@ -60,6 +60,7 @@ class AppDialogs {
   }
 
   static Widget createFormField({
+    Key? key,
     required BuildContext context,
     required String label,
     required TextEditingController controller,
@@ -78,6 +79,7 @@ class AppDialogs {
     void Function(String)? onSubmitted,
   }) {
     return AppTextField(
+      key: key,
       controller: controller,
       label: label,
       hintText: hintText,

--- a/lib/data/synctv_api/synctv_provider_service.dart
+++ b/lib/data/synctv_api/synctv_provider_service.dart
@@ -2394,17 +2394,25 @@ class SyncTvProviderDomainService {
     String username,
     String password, {
     String apiKey = '',
+    bool passwordless = false,
     String instanceName = '',
   }) async {
+    final hasApiKey = apiKey.trim().isNotEmpty;
+    if (hasApiKey && passwordless) {
+      throw ArgumentError('API Key 和无密码登录不能同时启用');
+    }
+    if (!hasApiKey && !passwordless && password.isEmpty) {
+      throw ArgumentError.value(password, 'password', '不能为空');
+    }
     final request = emby.LoginRequest(
       host: host,
       username: username,
       instanceName: instanceName,
     );
-    if (apiKey.trim().isNotEmpty) {
+    if (hasApiKey) {
       request.apiKey = apiKey;
     } else {
-      request.password = password;
+      request.password = passwordless ? '' : password;
     }
     final response = await _api.embyProvider.login(request);
     return EmbyLoginInfo(

--- a/lib/data/synctv_api/synctv_service.dart
+++ b/lib/data/synctv_api/synctv_service.dart
@@ -2694,6 +2694,7 @@ class SyncTvService {
     String username,
     String password, {
     String apiKey = '',
+    bool passwordless = false,
     String instanceName = '',
   }) async {
     return _domains.providers.loginEmbyInfo(
@@ -2701,6 +2702,7 @@ class SyncTvService {
       username,
       password,
       apiKey: apiKey,
+      passwordless: passwordless,
       instanceName: instanceName,
     );
   }

--- a/lib/features/providers/application/provider_gateway.dart
+++ b/lib/features/providers/application/provider_gateway.dart
@@ -437,6 +437,7 @@ abstract interface class ProviderGateway {
     String username,
     String password, {
     String apiKey = '',
+    bool passwordless = false,
     String instanceName = '',
   });
 

--- a/lib/features/providers/data/synctv_provider_gateway.dart
+++ b/lib/features/providers/data/synctv_provider_gateway.dart
@@ -772,12 +772,14 @@ final class SyncTvProviderGateway implements ProviderGateway {
     String username,
     String password, {
     String apiKey = '',
+    bool passwordless = false,
     String instanceName = '',
   }) => SyncTvService.loginEmbyInfo(
     host,
     username,
     password,
     apiKey: apiKey,
+    passwordless: passwordless,
     instanceName: instanceName,
   );
 

--- a/lib/features/providers/presentation/binding/platform_binding_dialog.dart
+++ b/lib/features/providers/presentation/binding/platform_binding_dialog.dart
@@ -41,6 +41,8 @@ enum _ProviderKind {
   tiktok,
 }
 
+enum _EmbyCredentialMode { password, apiKey, passwordless }
+
 String _providerKindType(_ProviderKind kind) {
   return switch (kind) {
     _ProviderKind.alist => 'alist',
@@ -574,6 +576,22 @@ class _PlatformBindingDialogState extends State<PlatformBindingDialog>
         icon: const Icon(Icons.live_tv_rounded, color: Color(0xFF9146FF)),
         iconColor: const Color(0xFF9146FF),
         content: TwitchAccountBindingForm(
+          instanceNamesLoader: () =>
+              providerGateway.listAvailableProviderInstances(
+                providerType: _providerType(kind),
+              ),
+          onSuccess: () => _loadBinds(kind, showLoading: false),
+        ),
+      );
+      return;
+    }
+    if (kind == _ProviderKind.emby) {
+      _showProviderFormDialog(
+        context: context,
+        title: context.l10n.bindProvider('Emby'),
+        icon: Icon(provider.icon, color: provider.color),
+        iconColor: provider.color,
+        content: EmbyAccountBindingForm(
           instanceNamesLoader: () =>
               providerGateway.listAvailableProviderInstances(
                 providerType: _providerType(kind),

--- a/lib/features/providers/presentation/binding/server_account_dialogs.dart
+++ b/lib/features/providers/presentation/binding/server_account_dialogs.dart
@@ -839,15 +839,56 @@ class _FnosAccountDialogState extends State<_FnosAccountDialog> {
   }
 }
 
+class EmbyAccountBindingForm extends StatelessWidget {
+  const EmbyAccountBindingForm({
+    super.key,
+    required this.instanceNamesLoader,
+    required this.onSuccess,
+    this.onBind,
+  });
+
+  final Future<List<String>> Function() instanceNamesLoader;
+  final VoidCallback onSuccess;
+  final Future<void> Function({
+    required String host,
+    required String username,
+    required String password,
+    required String apiKey,
+    required bool passwordless,
+    required String instanceName,
+  })?
+  onBind;
+
+  @override
+  Widget build(BuildContext context) {
+    return _PasswordAccountDialog(
+      kind: _ProviderKind.emby,
+      instanceNamesLoader: instanceNamesLoader,
+      onSuccess: onSuccess,
+      onLoginEmby: onBind,
+    );
+  }
+}
+
 class _PasswordAccountDialog extends StatefulWidget {
   final _ProviderKind kind;
   final Future<List<String>> Function() instanceNamesLoader;
   final VoidCallback onSuccess;
+  final Future<void> Function({
+    required String host,
+    required String username,
+    required String password,
+    required String apiKey,
+    required bool passwordless,
+    required String instanceName,
+  })?
+  onLoginEmby;
 
   const _PasswordAccountDialog({
     required this.kind,
     required this.instanceNamesLoader,
     required this.onSuccess,
+    this.onLoginEmby,
   });
 
   @override
@@ -864,7 +905,7 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
   final _otpSecretController = TextEditingController();
   List<String> _instanceNames = const [''];
   String _instanceName = '';
-  bool _useApiKey = false;
+  _EmbyCredentialMode _embyCredentialMode = _EmbyCredentialMode.password;
   bool _loadingInstances = true;
   bool _isLoading = false;
 
@@ -872,6 +913,11 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
   bool get _isEmby => widget.kind == _ProviderKind.emby;
   bool get _isCloudreve => widget.kind == _ProviderKind.cloudreve;
   bool get _isTrueNas => widget.kind == _ProviderKind.truenas;
+  bool get _isEmbyCredentialMissing => switch (_embyCredentialMode) {
+    _EmbyCredentialMode.password => _passwordController.text.isEmpty,
+    _EmbyCredentialMode.apiKey => _secretController.text.trim().isEmpty,
+    _EmbyCredentialMode.passwordless => false,
+  };
   String get _label => switch (widget.kind) {
     _ProviderKind.alist => 'AList',
     _ProviderKind.cloudreve => 'Cloudreve',
@@ -941,9 +987,7 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
         (_isTrueNas
             ? apiKey.isEmpty
             : username.isEmpty ||
-                  (_isEmby && _useApiKey
-                      ? apiKey.isEmpty
-                      : password.isEmpty))) {
+                  (_isEmby ? _isEmbyCredentialMissing : password.isEmpty))) {
       AppNotifications.showError(context, context.l10n.completeAllFields);
       return;
     }
@@ -979,14 +1023,31 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
           apiKey: apiKey,
           instanceName: _instanceName,
         );
-      } else {
-        await providerGateway.loginEmbyInfo(
-          host,
-          username,
-          password,
-          apiKey: _useApiKey ? apiKey : '',
-          instanceName: _instanceName,
-        );
+      } else if (_isEmby) {
+        final passwordless =
+            _embyCredentialMode == _EmbyCredentialMode.passwordless;
+        final selectedApiKey = _embyCredentialMode == _EmbyCredentialMode.apiKey
+            ? apiKey
+            : '';
+        if (widget.onLoginEmby case final login?) {
+          await login(
+            host: host,
+            username: username,
+            password: passwordless ? '' : password,
+            apiKey: selectedApiKey,
+            passwordless: passwordless,
+            instanceName: _instanceName,
+          );
+        } else {
+          await providerGateway.loginEmbyInfo(
+            host,
+            username,
+            passwordless ? '' : password,
+            apiKey: selectedApiKey,
+            passwordless: passwordless,
+            instanceName: _instanceName,
+          );
+        }
       }
       if (!mounted) return;
       Navigator.pop(context);
@@ -1064,6 +1125,7 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
                       ),
                       const SizedBox(height: 12),
                       AppDialogs.createFormField(
+                        key: _isEmby ? const Key('emby-bind-host') : null,
                         context: context,
                         label: context.l10n.providerAddress(_label),
                         controller: _hostController,
@@ -1077,6 +1139,7 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
                       ),
                       const SizedBox(height: 12),
                       AppDialogs.createFormField(
+                        key: _isEmby ? const Key('emby-bind-port') : null,
                         context: context,
                         label: context.l10n.port,
                         controller: _portController,
@@ -1104,6 +1167,7 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
                     children: [
                       if (!_isTrueNas) ...[
                         AppDialogs.createFormField(
+                          key: _isEmby ? const Key('emby-bind-username') : null,
                           context: context,
                           label: _isCloudreve ? 'Email' : context.l10n.username,
                           controller: _usernameController,
@@ -1112,38 +1176,67 @@ class _PasswordAccountDialogState extends State<_PasswordAccountDialog> {
                         const SizedBox(height: 12),
                       ],
                       if (_isEmby) ...[
-                        Align(
-                          alignment: Alignment.centerLeft,
-                          child: AppSegmentedControl<bool>(
-                            segments: [
-                              ButtonSegment(
-                                value: false,
-                                icon: const Icon(Icons.lock_outline_rounded),
-                                label: Text(context.l10n.password),
+                        LayoutBuilder(
+                          builder: (context, constraints) {
+                            final compact = constraints.maxWidth < 360;
+                            return Align(
+                              alignment: Alignment.centerLeft,
+                              child: AppSegmentedControl<_EmbyCredentialMode>(
+                                key: const Key('emby-bind-credential-mode'),
+                                segments: [
+                                  ButtonSegment(
+                                    value: _EmbyCredentialMode.password,
+                                    icon: const Icon(
+                                      Icons.lock_outline_rounded,
+                                    ),
+                                    label: compact
+                                        ? null
+                                        : Text(context.l10n.password),
+                                    tooltip: context.l10n.password,
+                                  ),
+                                  ButtonSegment(
+                                    value: _EmbyCredentialMode.apiKey,
+                                    icon: const Icon(Icons.key_rounded),
+                                    label: compact
+                                        ? null
+                                        : const Text('API Key'),
+                                    tooltip: 'API Key',
+                                  ),
+                                  ButtonSegment(
+                                    value: _EmbyCredentialMode.passwordless,
+                                    icon: const Icon(Icons.lock_open_rounded),
+                                    label: compact
+                                        ? null
+                                        : Text(context.l10n.noPassword),
+                                    tooltip: context.l10n.noPassword,
+                                  ),
+                                ],
+                                value: _embyCredentialMode,
+                                onChanged: (selected) => setState(
+                                  () => _embyCredentialMode = selected,
+                                ),
                               ),
-                              const ButtonSegment(
-                                value: true,
-                                icon: Icon(Icons.key_rounded),
-                                label: Text('API Key'),
-                              ),
-                            ],
-                            value: _useApiKey,
-                            onChanged: (selected) =>
-                                setState(() => _useApiKey = selected),
-                          ),
+                            );
+                          },
                         ),
                         const SizedBox(height: 12),
                       ],
-                      if (_useApiKey || _isTrueNas)
+                      if ((_isEmby &&
+                              _embyCredentialMode ==
+                                  _EmbyCredentialMode.apiKey) ||
+                          _isTrueNas)
                         AppDialogs.createFormField(
+                          key: _isEmby ? const Key('emby-bind-api-key') : null,
                           context: context,
                           label: 'API Key',
                           controller: _secretController,
                           prefixIcon: Icons.key_rounded,
                           obscureText: true,
                         )
-                      else
+                      else if (!_isEmby ||
+                          _embyCredentialMode == _EmbyCredentialMode.password)
                         AppDialogs.createFormField(
+                          key: _isEmby ? const Key('emby-bind-password') : null,
                           context: context,
                           label: context.l10n.password,
                           controller: _passwordController,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -702,6 +702,7 @@
   "providerAddressHint": "127.0.0.1 or https://example.com",
   "port": "Port",
   "loginCredentials": "Login credentials",
+  "noPassword": "No password",
   "twoFactorAuthentication": "Two-factor authentication",
   "oneTimeCode": "One-time code",
   "oneTimeCodeHint": "Enter when 2FA is enabled",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3678,6 +3678,12 @@ abstract class AppLocalizations {
   /// **'Login credentials'**
   String get loginCredentials;
 
+  /// No description provided for @noPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'No password'**
+  String get noPassword;
+
   /// No description provided for @twoFactorAuthentication.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2124,6 +2124,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginCredentials => 'Login credentials';
 
   @override
+  String get noPassword => 'No password';
+
+  @override
   String get twoFactorAuthentication => 'Two-factor authentication';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1977,6 +1977,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loginCredentials => '登录凭据';
 
   @override
+  String get noPassword => '无密码';
+
+  @override
   String get twoFactorAuthentication => '双因素验证';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -599,6 +599,7 @@
   "providerAddressHint": "127.0.0.1 或 https://example.com",
   "port": "端口",
   "loginCredentials": "登录凭据",
+  "noPassword": "无密码",
   "twoFactorAuthentication": "双因素验证",
   "oneTimeCode": "一次性验证码",
   "oneTimeCodeHint": "启用 2FA 时填写",

--- a/test/data/synctv_api/emby_provider_service_test.dart
+++ b/test/data/synctv_api/emby_provider_service_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:synctv_app/data/synctv_api/synctv_api_client.dart';
+import 'package:synctv_app/data/synctv_api/synctv_provider_service.dart';
+
+void main() {
+  late List<http.Request> requests;
+  late SyncTvProviderDomainService service;
+
+  setUp(() {
+    requests = [];
+    final api = SyncTvApiClient(
+      baseUrl: 'https://synctv.example',
+      session: SyncTvSession()..updateAccountTokens(accessToken: 'token'),
+      httpClient: MockClient((request) async {
+        requests.add(request);
+        return http.Response(
+          '{}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+    service = SyncTvProviderDomainService(api);
+  });
+
+  test('passwordless Emby login sends the empty password oneof', () async {
+    await service.loginEmbyInfo(
+      'https://emby.example',
+      'guest',
+      '',
+      passwordless: true,
+    );
+
+    final body = jsonDecode(requests.single.body) as Map<String, dynamic>;
+    expect(body, containsPair('password', ''));
+    expect(body, isNot(contains('apiKey')));
+  });
+
+  test('Emby login preserves password whitespace', () async {
+    const password = '  secret password\t';
+
+    await service.loginEmbyInfo('https://emby.example', 'alice', password);
+
+    final body = jsonDecode(requests.single.body) as Map<String, dynamic>;
+    expect(body['password'], password);
+  });
+
+  test(
+    'Emby login rejects an empty password without passwordless mode',
+    () async {
+      await expectLater(
+        service.loginEmbyInfo('https://emby.example', 'guest', ''),
+        throwsArgumentError,
+      );
+
+      expect(requests, isEmpty);
+    },
+  );
+
+  test('Emby login rejects API Key and passwordless mode together', () async {
+    await expectLater(
+      service.loginEmbyInfo(
+        'https://emby.example',
+        'guest',
+        '',
+        apiKey: 'key',
+        passwordless: true,
+      ),
+      throwsArgumentError,
+    );
+
+    expect(requests, isEmpty);
+  });
+}

--- a/test/features/providers/presentation/binding/platform_binding_emby_test.dart
+++ b/test/features/providers/presentation/binding/platform_binding_emby_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/features/providers/presentation/binding/platform_binding_dialog.dart';
+import 'package:synctv_app/l10n/app_localizations.dart';
+
+void main() {
+  testWidgets('Emby passwordless mode is explicit and submits empty password', (
+    tester,
+  ) async {
+    Map<String, Object?>? submission;
+    await _pumpEmbyForm(
+      tester,
+      onBind:
+          ({
+            required host,
+            required username,
+            required password,
+            required apiKey,
+            required passwordless,
+            required instanceName,
+          }) async {
+            submission = {
+              'host': host,
+              'username': username,
+              'password': password,
+              'apiKey': apiKey,
+              'passwordless': passwordless,
+              'instanceName': instanceName,
+            };
+          },
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('emby-bind-host')),
+      'https://emby.example',
+    );
+    await tester.enterText(
+      find.byKey(const Key('emby-bind-username')),
+      'guest',
+    );
+
+    await tester.tap(find.text('Log in'));
+    await tester.pump();
+    expect(submission, isNull);
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+
+    await _selectCredentialMode(tester, 2);
+    expect(find.byKey(const Key('emby-bind-password')), findsNothing);
+    expect(find.byKey(const Key('emby-bind-api-key')), findsNothing);
+
+    await tester.tap(find.text('Log in'));
+    await tester.pumpAndSettle();
+
+    expect(submission, {
+      'host': 'https://emby.example',
+      'username': 'guest',
+      'password': '',
+      'apiKey': '',
+      'passwordless': true,
+      'instanceName': '',
+    });
+    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('Emby credential modes show only their matching input', (
+    tester,
+  ) async {
+    await _pumpEmbyForm(tester);
+
+    expect(find.byKey(const Key('emby-bind-password')), findsOneWidget);
+    expect(find.byKey(const Key('emby-bind-api-key')), findsNothing);
+
+    await _selectCredentialMode(tester, 1);
+    expect(find.byKey(const Key('emby-bind-password')), findsNothing);
+    expect(find.byKey(const Key('emby-bind-api-key')), findsOneWidget);
+
+    await _selectCredentialMode(tester, 2);
+    expect(find.byKey(const Key('emby-bind-password')), findsNothing);
+    expect(find.byKey(const Key('emby-bind-api-key')), findsNothing);
+
+    await _selectCredentialMode(tester, 0);
+    expect(find.byKey(const Key('emby-bind-password')), findsOneWidget);
+    expect(find.byKey(const Key('emby-bind-api-key')), findsNothing);
+  });
+
+  testWidgets('Emby password mode preserves password whitespace', (
+    tester,
+  ) async {
+    String? submittedPassword;
+    bool? submittedPasswordless;
+    await _pumpEmbyForm(
+      tester,
+      onBind:
+          ({
+            required host,
+            required username,
+            required password,
+            required apiKey,
+            required passwordless,
+            required instanceName,
+          }) async {
+            submittedPassword = password;
+            submittedPasswordless = passwordless;
+          },
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('emby-bind-host')),
+      'https://emby.example',
+    );
+    await tester.enterText(
+      find.byKey(const Key('emby-bind-username')),
+      'alice',
+    );
+    await tester.enterText(
+      find.byKey(const Key('emby-bind-password')),
+      '  secret password\t',
+    );
+    await tester.tap(find.text('Log in'));
+    await tester.pumpAndSettle();
+
+    expect(submittedPassword, '  secret password\t');
+    expect(submittedPasswordless, isFalse);
+    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('Emby credential selector fits compact layouts', (tester) async {
+    await _pumpEmbyForm(tester, surfaceSize: const Size(320, 700));
+
+    expect(find.byTooltip('Password'), findsOneWidget);
+    expect(find.byTooltip('API Key'), findsOneWidget);
+    expect(find.byTooltip('No password'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpEmbyForm(
+  WidgetTester tester, {
+  Future<void> Function({
+    required String host,
+    required String username,
+    required String password,
+    required String apiKey,
+    required bool passwordless,
+    required String instanceName,
+  })?
+  onBind,
+  Size surfaceSize = const Size(900, 760),
+}) async {
+  await tester.binding.setSurfaceSize(surfaceSize);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: EmbyAccountBindingForm(
+          instanceNamesLoader: () async => const [],
+          onSuccess: () {},
+          onBind: onBind,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  expect(find.byKey(const Key('emby-bind-credential-mode')), findsOneWidget);
+}
+
+Future<void> _selectCredentialMode(WidgetTester tester, int index) async {
+  final control = find.byKey(const Key('emby-bind-credential-mode'));
+  final segment = find
+      .descendant(of: control, matching: find.byType(TextButton))
+      .at(index);
+  tester.widget<TextButton>(segment).onPressed!();
+  await tester.pump();
+}


### PR DESCRIPTION
## Summary
- Add password, API key, and passwordless credential modes for Emby account binding.
- Send an explicit empty password for passwordless mode while rejecting ambiguous empty-password input.
- Preserve password whitespace and reject conflicting API key/passwordless selections in the service layer.
- Add responsive credential controls, localized labels, and regression tests.

## Validation
- `flutter analyze` passed with no issues.
- Full Flutter test suite: 916 passed.
- Focused service and widget tests passed.
- Real macOS app flow verified passwordless binding and normal password rebinding.