### PR TITLE
refactor: remove unused APIs and legacy compatibility

### DIFF
--- a/integration_test/backend/multi_user_realtime_e2e_test.dart
+++ b/integration_test/backend/multi_user_realtime_e2e_test.dart
@@ -88,7 +88,7 @@ void main() {
           source: preview.source,
           name: 'Multi-user bee',
         );
-        await SyncTvService.switchMediaAndPlay(roomId, mediaId);
+        await SyncTvService.switchMedia(roomId, mediaId);
         await SyncTvService.updatePlaybackState(
           roomId,
           isPlaying: true,

--- a/lib/contracts/room_media_models.dart
+++ b/lib/contracts/room_media_models.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+
+import 'package:synctv_app/contracts/proto_mapping.dart';
 import 'package:synctv_app/contracts/synctv_models.dart';
+import 'package:synctv_app/src/generated/proto/client.pb.dart' as client;
 import 'package:synctv_app/src/generated/proto/client.pbenum.dart'
     as client_enum;
 
@@ -54,7 +58,7 @@ class RoomMediaLibraryPage {
   bool hasNextPage(int pageSize) {
     if (usesCursor) return nextCursor.isNotEmpty;
     if (total case final total?) return page * pageSize < total;
-    return entries.length >= pageSize;
+    return playlists.length + media.length + dynamicItems.length >= pageSize;
   }
 
   int get effectivePlaylistCount =>
@@ -126,6 +130,23 @@ class StoredImageInfo {
     required this.height,
     this.metadata = const [],
   });
+
+  factory StoredImageInfo.fromChatAttachment(
+    client.ChatAttachment image, {
+    String Function(String)? resolveUrl,
+  }) {
+    return StoredImageInfo(
+      id: image.id,
+      storageBackend: '',
+      objectKey: '',
+      url: resolveUrl?.call(image.url) ?? image.url,
+      mimeType: image.mimeType,
+      sizeBytes: image.sizeBytes.toInt(),
+      width: image.width,
+      height: image.height,
+      metadata: utf8.encode(jsonEncode(fileMetadataToJson(image.metadata))),
+    );
+  }
 }
 
 class ChatHistoryPage {
@@ -191,6 +212,16 @@ class ChatReactionSummaryInfo {
     required this.reactedByMe,
   });
 
+  factory ChatReactionSummaryInfo.fromProto(
+    client.ChatReactionSummary reaction,
+  ) {
+    return ChatReactionSummaryInfo(
+      key: reaction.key,
+      count: reaction.count.toInt(),
+      reactedByMe: reaction.reactedByMe,
+    );
+  }
+
   final String key;
   final int count;
   final bool reactedByMe;
@@ -249,6 +280,15 @@ class ChatPinInfo {
     required this.pinnedAt,
   });
 
+  factory ChatPinInfo.fromProto(client.ChatMessagePin pin) {
+    return ChatPinInfo(
+      pinnedByUserId: pin.pinnedByUserId,
+      pinnedByUsername: pin.pinnedByUsername,
+      note: pin.note,
+      pinnedAt: pin.pinnedAt.toInt(),
+    );
+  }
+
   final String pinnedByUserId;
   final String pinnedByUsername;
   final String note;
@@ -272,6 +312,24 @@ class ChatPinEventInfo {
     required this.occurredAt,
     required this.sequence,
   });
+
+  factory ChatPinEventInfo.fromProto(
+    client.ChatPinEvent event, {
+    String Function(String)? resolveUrl,
+  }) {
+    return ChatPinEventInfo(
+      eventId: event.eventId,
+      roomId: event.roomId,
+      kind: event.kind,
+      message: RoomChatMessageInfo.fromProto(
+        event.message,
+        resolveUrl: resolveUrl,
+      ),
+      pin: event.hasPin() ? ChatPinInfo.fromProto(event.pin) : null,
+      occurredAt: event.occurredAt.toInt(),
+      sequence: event.sequence.toInt(),
+    );
+  }
 
   final String eventId;
   final String roomId;
@@ -324,6 +382,42 @@ class RoomChatMessageInfo {
     this.mentions = const [],
     this.pin,
   });
+
+  factory RoomChatMessageInfo.fromProto(
+    client.ChatMessageReceive message, {
+    String Function(String)? resolveUrl,
+  }) {
+    return RoomChatMessageInfo(
+      id: message.id,
+      roomId: message.roomId,
+      userId: message.userId,
+      username: message.hasUsername() ? message.username : null,
+      content: message.content,
+      timestamp: message.timestamp.toInt(),
+      messageType: message.messageType,
+      displayPosition: message.displayPosition,
+      displayColor: message.displayColor,
+      version: message.version.toInt(),
+      editedAt: message.editedAt.toInt(),
+      deletedAt: message.deletedAt.toInt(),
+      status: message.status,
+      replyToMessageId: message.replyToMessageId,
+      images: message.attachments
+          .map(
+            (image) => StoredImageInfo.fromChatAttachment(
+              image,
+              resolveUrl: resolveUrl,
+            ),
+          )
+          .toList(),
+      reactions: message.reactions
+          .map(ChatReactionSummaryInfo.fromProto)
+          .toList(),
+      reactionCount: message.reactionCount,
+      mentions: message.mentions.map(ChatMentionInfo.fromProto).toList(),
+      pin: message.hasPin() ? ChatPinInfo.fromProto(message.pin) : null,
+    );
+  }
 
   double? get position => double.tryParse(displayPosition);
   String? get color => displayColor.isEmpty ? null : displayColor;
@@ -401,4 +495,13 @@ class ChatMentionInfo {
     required this.start,
     required this.length,
   });
+
+  factory ChatMentionInfo.fromProto(client.ChatMention mention) {
+    return ChatMentionInfo(
+      userId: mention.userId,
+      username: mention.username,
+      start: mention.start,
+      length: mention.length,
+    );
+  }
 }

--- a/lib/contracts/synctv_models.dart
+++ b/lib/contracts/synctv_models.dart
@@ -1005,12 +1005,15 @@ class RoomMediaEntry {
           : info.medias[formatMediaIndex].format;
       final staticDanmaku = _danmakuFromProto(
         info.danmakus,
-        stream: false,
+        delivery:
+            client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_DOCUMENT,
         resolveUrl: resolveUrl,
       );
       final streamDanmaku = _danmakuFromProto(
         info.danmakus,
-        stream: true,
+        delivery: client
+            .PlaybackDanmakuDelivery
+            .PLAYBACK_DANMAKU_DELIVERY_EVENT_STREAM,
         resolveUrl: resolveUrl,
       );
 
@@ -1071,14 +1074,14 @@ class RoomMediaEntry {
   })?
   _danmakuFromProto(
     Iterable<client.PlaybackDanmaku> danmakus, {
-    required bool stream,
+    required client.PlaybackDanmakuDelivery delivery,
     String Function(String url)? resolveUrl,
   }) {
     for (final danmaku in danmakus) {
       final url = danmaku.url.trim();
       if (url.isEmpty) continue;
-      if (_isStreamDanmu(danmaku) != stream) continue;
-      final delivery = danmaku.hasP2pDelivery()
+      if (danmaku.delivery != delivery) continue;
+      final p2pDelivery = danmaku.hasP2pDelivery()
           ? P2pResourceDelivery(
               swarmId: danmaku.p2pDelivery.swarmId,
               swarmTicket: danmaku.p2pDelivery.swarmTicket,
@@ -1087,31 +1090,10 @@ class RoomMediaEntry {
       return (
         url: resolveUrl == null ? url : resolveUrl(url),
         headers: Map<String, String>.from(danmaku.headers),
-        p2pDelivery: delivery,
+        p2pDelivery: p2pDelivery,
       );
     }
     return null;
-  }
-
-  static bool _isStreamDanmu(client.PlaybackDanmaku danmaku) {
-    final delivery = danmaku.delivery;
-    if (delivery ==
-        client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_EVENT_STREAM) {
-      return true;
-    }
-    if (delivery ==
-        client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_DOCUMENT) {
-      return false;
-    }
-
-    final format = danmaku.format.trim().toLowerCase();
-    if (format == 'synctv-bilibili-live') return true;
-    if (format == 'synctv-twitch-live') return true;
-    if (format == 'synctv-huya-live') return true;
-    if (format == 'synctv-douyu-live') return true;
-    if (format == 'synctv-douyin-live') return true;
-    if (format == 'synctv-acfun-live') return true;
-    return danmaku.url.contains('/live-danmaku/');
   }
 }
 

--- a/lib/data/synctv_api/synctv_admin_service.dart
+++ b/lib/data/synctv_api/synctv_admin_service.dart
@@ -663,11 +663,6 @@ class SyncTvAdminDomainService {
     );
   }
 
-  Future<List<SyncTvUser>> listAdmins({String search = ''}) async {
-    final page = await listAdminsPage(page: 1, pageSize: 100, search: search);
-    return page.admins;
-  }
-
   Future<void> addAdmin(String userId) async {
     await _api.adminService.addAdmin(admin.AddAdminRequest(userId: userId));
   }
@@ -840,31 +835,6 @@ class SyncTvAdminDomainService {
     );
   }
 
-  Future<List<AdminProviderInstance>> listProviderInstances({
-    String providerType = '',
-    String search = '',
-    bool? enabled,
-    bool? tls,
-    provider_common_enum.ProviderInstanceListSortBy sortBy =
-        provider_common_enum
-            .ProviderInstanceListSortBy
-            .PROVIDER_INSTANCE_LIST_SORT_BY_NAME,
-    provider_common_enum.SortDirection sortDirection =
-        provider_common_enum.SortDirection.SORT_DIRECTION_ASC,
-  }) async {
-    final page = await listProviderInstancesPage(
-      page: 1,
-      pageSize: 100,
-      providerType: providerType,
-      search: search,
-      enabled: enabled,
-      tls: tls,
-      sortBy: sortBy,
-      sortDirection: sortDirection,
-    );
-    return page.instances;
-  }
-
   Future<List<String>> listAvailableProviderInstances({
     String providerType = '',
   }) async {
@@ -997,31 +967,6 @@ class SyncTvAdminDomainService {
       streams: response.streams.map(_activeStreamFromProto).toList(),
       total: response.total,
     );
-  }
-
-  Future<List<AdminActiveStream>> listActiveStreams({
-    int page = 1,
-    int pageSize = 50,
-    String roomId = '',
-    String userId = '',
-    String nodeId = '',
-    String search = '',
-    admin_enum.ActiveStreamListSortBy sortBy =
-        admin_enum.ActiveStreamListSortBy.ACTIVE_STREAM_LIST_SORT_BY_STARTED_AT,
-    admin_enum.SortDirection sortDirection =
-        admin_enum.SortDirection.SORT_DIRECTION_DESC,
-  }) async {
-    final pageResult = await listActiveStreamsPage(
-      page: page,
-      pageSize: pageSize,
-      roomId: roomId,
-      userId: userId,
-      nodeId: nodeId,
-      search: search,
-      sortBy: sortBy,
-      sortDirection: sortDirection,
-    );
-    return pageResult.streams;
   }
 
   Future<void> kickStream(AdminActiveStream stream) async {

--- a/lib/data/synctv_api/synctv_api_facades.dart
+++ b/lib/data/synctv_api/synctv_api_facades.dart
@@ -768,17 +768,6 @@ class SyncTvUserApi {
       client.UnfavoriteRoomResponse.create,
     );
   }
-
-  Future<client.ListFavoriteRoomsResponse> listFavoriteRooms(
-    client.ListFavoriteRoomsRequest request,
-  ) {
-    return _api._send(
-      'GET',
-      '/api/user/favorite-rooms',
-      client.ListFavoriteRoomsResponse.create,
-      query: _api._messageQuery(request),
-    );
-  }
 }
 
 class SyncTvRoomApi {
@@ -2589,30 +2578,6 @@ class SyncTvAdminApi {
     );
   }
 
-  Future<client.GetChatHistoryResponse> getRoomChatHistory(
-    String roomId,
-    client.GetChatHistoryRequest request,
-  ) {
-    return _api._send(
-      'GET',
-      '/api/admin/rooms/$roomId/chat/history',
-      client.GetChatHistoryResponse.create,
-      query: _api._messageQuery(request),
-    );
-  }
-
-  Future<client.GetChatMessageContextResponse> getRoomChatMessageContext(
-    String roomId,
-    client.GetChatMessageContextRequest request,
-  ) {
-    return _api._send(
-      'GET',
-      '/api/admin/rooms/$roomId/chat/messages/${request.messageId}/context',
-      client.GetChatMessageContextResponse.create,
-      query: _api._messageQuery(request)..remove('messageId'),
-    );
-  }
-
   Future<admin.AdminUser> unbanUser(admin.UnbanUserRequest request) {
     return _api._send(
       'POST',
@@ -4079,17 +4044,6 @@ class SyncTvBilibiliProviderApi {
       'POST',
       '/api/providers/bilibili/pgc/followed',
       bilibili.ListFollowedPgcResponse.create,
-      body: request,
-    );
-  }
-
-  Future<bilibili.ListHistoryResponse> listHistory(
-    bilibili.ListHistoryRequest request,
-  ) {
-    return _api._send(
-      'POST',
-      '/api/providers/bilibili/history',
-      bilibili.ListHistoryResponse.create,
       body: request,
     );
   }

--- a/lib/data/synctv_api/synctv_provider_service.dart
+++ b/lib/data/synctv_api/synctv_provider_service.dart
@@ -1768,23 +1768,6 @@ class SyncTvProviderDomainService {
     );
   }
 
-  Future<bilibili.ListHistoryResponse> listBilibiliHistory({
-    source_enum.BilibiliHistoryType type =
-        source_enum.BilibiliHistoryType.BILIBILI_HISTORY_TYPE_ALL,
-    String? cursor,
-    int pageSize = 30,
-    String instanceName = '',
-    bool shared = false,
-  }) => _api.bilibiliProvider.listHistory(
-    bilibili.ListHistoryRequest(
-      type: type,
-      cursor: cursor,
-      pageSize: pageSize,
-      instanceName: instanceName,
-      shared: shared,
-    ),
-  );
-
   Future<BilibiliPgcTimelineInfo> listBilibiliPgcTimeline({
     required BilibiliPgcTimelineKind type,
     int beforeDays = 3,

--- a/lib/data/synctv_api/synctv_public_room_service.dart
+++ b/lib/data/synctv_api/synctv_public_room_service.dart
@@ -241,40 +241,6 @@ class SyncTvPublicRoomDomainService {
     );
   }
 
-  Future<RoomsPage> getFavoriteRoomsPage({
-    int page = 1,
-    int pageSize = 100,
-    String? search,
-  }) async {
-    if (_api.session.identity is GuestSessionIdentity) {
-      return RoomsPage(
-        rooms: const <SyncTvRoom>[],
-        total: 0,
-        page: page,
-        pageSize: pageSize,
-      );
-    }
-    final response = await _api.user.listFavoriteRooms(
-      client.ListFavoriteRoomsRequest(
-        page: page,
-        pageSize: pageSize,
-        search: search ?? '',
-      ),
-    );
-    return RoomsPage(
-      rooms: response.rooms
-          .map(
-            (room) => _api
-                .mapRoom(room)
-                .copyWith(joined: true, canJoin: false, isFavorite: true),
-          )
-          .toList(growable: false),
-      total: response.total,
-      page: page,
-      pageSize: pageSize,
-    );
-  }
-
   Future<SyncTvRoom> favoriteRoom(String roomId) async {
     final response = await _api.user.favoriteRoom(
       client.FavoriteRoomRequest(roomId: roomId),

--- a/lib/data/synctv_api/synctv_room_management_service.dart
+++ b/lib/data/synctv_api/synctv_room_management_service.dart
@@ -147,31 +147,6 @@ class SyncTvRoomManagementDomainService {
         });
   }
 
-  Stream<RoomResourceWatchEvent<List<SyncTvUser>>> watchRoomUsers(
-    String roomId, {
-    String version = '',
-  }) {
-    return watchRoomMembers(roomId, version: version).map((event) {
-      return switch (event) {
-        RoomResourceObserved(:final version, :final changed) =>
-          RoomResourceWatchEvent<List<SyncTvUser>>.observed(
-            version: version,
-            changed: changed,
-          ),
-        RoomResourceChanged(:final version, :final snapshot) =>
-          RoomResourceWatchEvent<List<SyncTvUser>>.changed(
-            version: version,
-            snapshot: snapshot?.map(roomMemberToUser).toList(growable: false),
-          ),
-        RoomResourceWatchFailed(:final message, :final code) =>
-          RoomResourceWatchEvent<List<SyncTvUser>>.error(
-            message: message,
-            code: code,
-          ),
-      };
-    });
-  }
-
   Future<List<IceServerInfo>> getIceServers(String roomId) async {
     final response = await _api.room.getIceServers(
       roomId,
@@ -539,18 +514,6 @@ AdminRoomMember roomMemberFromProto(common.RoomMember member) {
     adminRemovedPermissions: member.adminRemovedPermissions.toInt(),
     joinedAt: member.joinedAt.toInt(),
     isOnline: member.isOnline,
-    connectionCount: member.connectionCount,
-  );
-}
-
-SyncTvUser roomMemberToUser(AdminRoomMember member) {
-  return SyncTvUser(
-    id: member.userId,
-    username: member.username,
-    role: RoomMembershipRole(member.role),
-    createdAt: member.joinedAt,
-    status: common_enum.UserStatus.USER_STATUS_ACTIVE,
-    onlineCount: member.isOnline ? 1 : 0,
     connectionCount: member.connectionCount,
   );
 }

--- a/lib/data/synctv_api/synctv_room_media_service.dart
+++ b/lib/data/synctv_api/synctv_room_media_service.dart
@@ -914,16 +914,9 @@ class SyncTvRoomMediaDomainService {
   }
 
   StoredImageInfo storedImageFromChatAttachment(client.ChatAttachment image) {
-    return StoredImageInfo(
-      id: image.id,
-      storageBackend: '',
-      objectKey: '',
-      url: _api.resolveResourceUrl(image.url),
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes.toInt(),
-      width: image.width,
-      height: image.height,
-      metadata: utf8.encode(jsonEncode(fileMetadataToJson(image.metadata))),
+    return StoredImageInfo.fromChatAttachment(
+      image,
+      resolveUrl: _api.resolveResourceUrl,
     );
   }
 
@@ -1177,35 +1170,9 @@ class SyncTvRoomMediaDomainService {
   }
 
   RoomChatMessageInfo _chatMessageFromProto(client.ChatMessageReceive message) {
-    return RoomChatMessageInfo(
-      id: message.id,
-      roomId: message.roomId,
-      userId: message.userId,
-      username: message.hasUsername() ? message.username : null,
-      content: message.content,
-      timestamp: message.timestamp.toInt(),
-      messageType: message.messageType,
-      displayPosition: message.displayPosition,
-      displayColor: message.displayColor,
-      version: message.version.toInt(),
-      editedAt: message.editedAt.toInt(),
-      deletedAt: message.deletedAt.toInt(),
-      status: message.status,
-      replyToMessageId: message.replyToMessageId,
-      images: message.attachments.map(storedImageFromChatAttachment).toList(),
-      reactions: message.reactions.map(_chatReactionSummaryFromProto).toList(),
-      reactionCount: message.reactionCount,
-      mentions: message.mentions
-          .map(
-            (mention) => ChatMentionInfo(
-              userId: mention.userId,
-              username: mention.username,
-              start: mention.start,
-              length: mention.length,
-            ),
-          )
-          .toList(),
-      pin: message.hasPin() ? _chatPinFromProto(message.pin) : null,
+    return RoomChatMessageInfo.fromProto(
+      message,
+      resolveUrl: _api.resolveResourceUrl,
     );
   }
 
@@ -1224,33 +1191,9 @@ class SyncTvRoomMediaDomainService {
   }
 
   ChatPinEventInfo _chatPinEventFromProto(client.ChatPinEvent event) {
-    return ChatPinEventInfo(
-      eventId: event.eventId,
-      roomId: event.roomId,
-      kind: event.kind,
-      message: _chatMessageFromProto(event.message),
-      pin: event.hasPin() ? _chatPinFromProto(event.pin) : null,
-      occurredAt: event.occurredAt.toInt(),
-      sequence: event.sequence.toInt(),
-    );
-  }
-
-  ChatPinInfo _chatPinFromProto(client.ChatMessagePin pin) {
-    return ChatPinInfo(
-      pinnedByUserId: pin.pinnedByUserId,
-      pinnedByUsername: pin.pinnedByUsername,
-      note: pin.note,
-      pinnedAt: pin.pinnedAt.toInt(),
-    );
-  }
-
-  ChatReactionSummaryInfo _chatReactionSummaryFromProto(
-    client.ChatReactionSummary reaction,
-  ) {
-    return ChatReactionSummaryInfo(
-      key: reaction.key,
-      count: reaction.count.toInt(),
-      reactedByMe: reaction.reactedByMe,
+    return ChatPinEventInfo.fromProto(
+      event,
+      resolveUrl: _api.resolveResourceUrl,
     );
   }
 

--- a/lib/data/synctv_api/synctv_room_media_service.dart
+++ b/lib/data/synctv_api/synctv_room_media_service.dart
@@ -497,24 +497,6 @@ class SyncTvRoomMediaDomainService {
     return chatHistoryPageFromProto(response);
   }
 
-  Future<ChatHistoryPage> getChatHistoryAsAdmin(
-    String roomId, {
-    int limit = 50,
-    String cursor = '',
-    List<client_enum.ChatMessageType> includeMessageTypes =
-        chatTimelineMessageTypes,
-  }) async {
-    final response = await _api.adminService.getRoomChatHistory(
-      roomId,
-      client.GetChatHistoryRequest(
-        limit: limit,
-        cursor: cursor,
-        includeMessageTypes: includeMessageTypes,
-      ),
-    );
-    return chatHistoryPageFromProto(response);
-  }
-
   ChatHistoryPage chatHistoryPageFromProto(
     client.GetChatHistoryResponse response,
   ) {
@@ -842,25 +824,6 @@ class SyncTvRoomMediaDomainService {
     return _chatMessageContextFromProto(response);
   }
 
-  Future<ChatMessageContextInfo> getChatMessageContextAsAdmin(
-    String roomId,
-    String messageId, {
-    int beforeLimit = 20,
-    int afterLimit = 20,
-    bool includeDeleted = false,
-  }) async {
-    final response = await _api.adminService.getRoomChatMessageContext(
-      roomId,
-      client.GetChatMessageContextRequest(
-        messageId: messageId,
-        beforeLimit: beforeLimit,
-        afterLimit: afterLimit,
-        includeDeleted: includeDeleted,
-      ),
-    );
-    return _chatMessageContextFromProto(response);
-  }
-
   ChatMessageContextInfo _chatMessageContextFromProto(
     client.GetChatMessageContextResponse response,
   ) {
@@ -1018,11 +981,7 @@ class SyncTvRoomMediaDomainService {
       streamKey: response.streamKey,
       whipUrl: response.whipUrl,
       expiresAt: response.hasExpiresAt() ? response.expiresAt.toInt() : null,
-      keyType:
-          response.type ==
-              client_enum.PublishKeyType.PUBLISH_KEY_TYPE_UNSPECIFIED
-          ? client_enum.PublishKeyType.PUBLISH_KEY_TYPE_SINGLE_USE
-          : response.type,
+      keyType: response.type,
     );
   }
 

--- a/lib/data/synctv_api/synctv_service.dart
+++ b/lib/data/synctv_api/synctv_service.dart
@@ -11,7 +11,6 @@ import 'package:synctv_app/contracts/room_management_models.dart';
 import 'package:synctv_app/contracts/room_media_models.dart';
 import 'package:synctv_app/features/room/domain/room_realtime.dart';
 import 'package:synctv_app/contracts/synctv_models.dart';
-import 'package:synctv_app/features/auth/domain/oauth2_callback_parser.dart';
 import 'package:synctv_app/data/synctv_api/synctv_api_client.dart';
 import 'package:synctv_app/core/time/synced_clock.dart';
 import 'package:synctv_app/data/synctv_api/synctv_domain_services.dart';
@@ -27,8 +26,6 @@ import 'package:synctv_app/src/generated/proto/common.pbenum.dart'
     as common_enum;
 import 'package:synctv_app/src/generated/proto/providers/bilibili.pbenum.dart'
     as bilibili_enum;
-import 'package:synctv_app/src/generated/proto/providers/bilibili.pb.dart'
-    as bilibili;
 import 'package:synctv_app/src/generated/proto/providers/common.pbenum.dart'
     as provider_common_enum;
 import 'package:synctv_app/src/generated/proto/providers/common.pb.dart'
@@ -387,10 +384,6 @@ class SyncTvService {
     );
   }
 
-  static DateTime serverNow() => SyncedClock.now();
-
-  static int serverNowMillis() => SyncedClock.nowMillis();
-
   static Future<void> syncServerTime({bool refresh = false}) async {
     if (!refresh && SyncedClock.isSynced) return;
     final revision = ++_serverTimeSyncRevision;
@@ -468,11 +461,6 @@ class SyncTvService {
       native: native,
     );
   }
-
-  static OAuth2CallbackPayload parseOAuth2Callback(
-    Uri uri, {
-    String expectedState = '',
-  }) => OAuth2CallbackParser.parse(uri, expectedState: expectedState);
 
   static Future<AuthResult> finishOAuth2Login({
     required String code,
@@ -824,40 +812,14 @@ class SyncTvService {
     );
   }
 
-  static Future<RoomsPage> getFavoriteRoomsPage({
-    int page = 1,
-    int pageSize = 100,
-    String? search,
-    bool refresh = false,
-  }) async {
-    final key = [
-      'account:favorite-rooms',
-      page,
-      pageSize,
-      search ?? '',
-    ].join('|');
-    return _domains.cache.get<RoomsPage>(
-      key,
-      ttl: const Duration(seconds: 45),
-      refresh: refresh,
-      loader: () => _domains.publicRooms.getFavoriteRoomsPage(
-        page: page,
-        pageSize: pageSize,
-        search: search,
-      ),
-    );
-  }
-
   static Future<SyncTvRoom> favoriteRoom(String roomId) async {
     final room = await _domains.publicRooms.favoriteRoom(roomId);
-    _domains.cache.invalidatePrefix('account:favorite-rooms');
     _domains.cache.invalidatePrefix('account:rooms');
     return room;
   }
 
   static Future<SyncTvRoom> unfavoriteRoom(String roomId) async {
     final room = await _domains.publicRooms.unfavoriteRoom(roomId);
-    _domains.cache.invalidatePrefix('account:favorite-rooms');
     _domains.cache.invalidatePrefix('account:rooms');
     return room;
   }
@@ -1025,13 +987,6 @@ class SyncTvService {
     String version = '',
   }) {
     return _domains.roomManagement.watchRoomMembers(roomId, version: version);
-  }
-
-  static Stream<RoomResourceWatchEvent<List<SyncTvUser>>> watchRoomUsers(
-    String roomId, {
-    String version = '',
-  }) {
-    return _domains.roomManagement.watchRoomUsers(roomId, version: version);
   }
 
   static Future<RoomMediaLibraryPage> listMediaLibrary(
@@ -1325,37 +1280,6 @@ class SyncTvService {
       limit: limit,
       cursor: cursor,
       includeMessageTypes: includeMessageTypes,
-    );
-  }
-
-  static Future<ChatHistoryPage> getAdminChatHistory(
-    String roomId, {
-    int limit = 50,
-    String cursor = '',
-    List<client_enum.ChatMessageType> includeMessageTypes =
-        chatTimelineMessageTypes,
-  }) {
-    return _domains.roomMedia.getChatHistoryAsAdmin(
-      roomId,
-      limit: limit,
-      cursor: cursor,
-      includeMessageTypes: includeMessageTypes,
-    );
-  }
-
-  static Future<ChatMessageContextInfo> getAdminChatMessageContext(
-    String roomId,
-    String messageId, {
-    int beforeLimit = 20,
-    int afterLimit = 20,
-    bool includeDeleted = false,
-  }) {
-    return _domains.roomMedia.getChatMessageContextAsAdmin(
-      roomId,
-      messageId,
-      beforeLimit: beforeLimit,
-      afterLimit: afterLimit,
-      includeDeleted: includeDeleted,
     );
   }
 
@@ -1734,20 +1658,6 @@ class SyncTvService {
     );
   }
 
-  static Future<SyncTvPlaybackStatus> switchMediaAndPlay(
-    String roomId,
-    String entryId, {
-    String? subPath,
-    String? playlistId,
-  }) {
-    return switchMedia(
-      roomId,
-      entryId,
-      subPath: subPath,
-      playlistId: playlistId,
-    );
-  }
-
   static Future<SyncTvPlaybackStatus> updatePlaybackState(
     String roomId, {
     PlaybackControlAction? action,
@@ -1764,20 +1674,6 @@ class SyncTvService {
       speed: speed,
       version: version,
     );
-  }
-
-  static Duration? resourceWatchReconnectDelay(Object error) {
-    if (error is SyncTvApiException) {
-      if (error.statusCode == 401 ||
-          error.statusCode == 403 ||
-          error.statusCode == 404) {
-        return null;
-      }
-      if (error.statusCode == 429) return const Duration(seconds: 30);
-      if (error.statusCode >= 400 && error.statusCode < 500) return null;
-      return const Duration(seconds: 10);
-    }
-    return const Duration(seconds: 5);
   }
 
   static Future<AlistLoginInfo> loginAList(
@@ -2523,66 +2419,28 @@ class SyncTvService {
     );
   }
 
-  static Future<List<AlistBindInfo>> getAlistBindInfos({
-    String instanceName = '',
-  }) async {
-    return _domains.providers.getAlistBindInfos(instanceName: instanceName);
-  }
-
   static Future<List<AlistBindInfo>> getAllAlistBindInfos() async {
     return _domains.providers.getAllAlistBindInfos();
-  }
-
-  static Future<List<EmbyBindInfo>> getEmbyBindInfos({
-    String instanceName = '',
-  }) async {
-    return _domains.providers.getEmbyBindInfos(instanceName: instanceName);
   }
 
   static Future<List<EmbyBindInfo>> getAllEmbyBindInfos() async {
     return _domains.providers.getAllEmbyBindInfos();
   }
 
-  static Future<List<CloudreveBindInfo>> getCloudreveBindInfos({
-    String instanceName = '',
-  }) => _domains.providers.getCloudreveBindInfos(instanceName: instanceName);
-
   static Future<List<CloudreveBindInfo>> getAllCloudreveBindInfos() =>
       _domains.providers.getAllCloudreveBindInfos();
-
-  static Future<List<TwitchBindInfo>> getTwitchBindInfos({
-    String instanceName = '',
-  }) => _domains.providers.getTwitchBindInfos(instanceName: instanceName);
 
   static Future<List<TwitchBindInfo>> getAllTwitchBindInfos() =>
       _domains.providers.getAllTwitchBindInfos();
 
-  static Future<List<YoutubeBindInfo>> getYoutubeBindInfos({
-    String instanceName = '',
-  }) => _domains.providers.getYoutubeBindInfos(instanceName: instanceName);
-
   static Future<List<YoutubeBindInfo>> getAllYoutubeBindInfos() =>
       _domains.providers.getAllYoutubeBindInfos();
-
-  static Future<List<DouyinBindInfo>> getDouyinBindInfos({
-    String instanceName = '',
-  }) => _domains.providers.getDouyinBindInfos(instanceName: instanceName);
 
   static Future<List<DouyinBindInfo>> getAllDouyinBindInfos() =>
       _domains.providers.getAllDouyinBindInfos();
 
-  static Future<List<TikTokBindInfo>> getTikTokBindInfos({
-    String instanceName = '',
-  }) => _domains.providers.getTikTokBindInfos(instanceName: instanceName);
-
   static Future<List<TikTokBindInfo>> getAllTikTokBindInfos() =>
       _domains.providers.getAllTikTokBindInfos();
-
-  static Future<List<BilibiliBindInfo>> getBilibiliBindInfos({
-    String instanceName = '',
-  }) async {
-    return _domains.providers.getBilibiliBindInfos(instanceName: instanceName);
-  }
 
   static Future<List<BilibiliBindInfo>> getAllBilibiliBindInfos() async {
     return _domains.providers.getAllBilibiliBindInfos();
@@ -2613,19 +2471,6 @@ class SyncTvService {
     String instanceName = '',
   }) => _domains.providers.getCloudreveAccount(
     serverId,
-    instanceName: instanceName,
-  );
-
-  static Future<bilibili.ListHistoryResponse> listBilibiliHistory({
-    source_enum.BilibiliHistoryType type =
-        source_enum.BilibiliHistoryType.BILIBILI_HISTORY_TYPE_ALL,
-    String? cursor,
-    int pageSize = 30,
-    String instanceName = '',
-  }) => _domains.providers.listBilibiliHistory(
-    type: type,
-    cursor: cursor,
-    pageSize: pageSize,
     instanceName: instanceName,
   );
 
@@ -2806,7 +2651,6 @@ class SyncTvService {
       isPublic,
     );
     _domains.cache.invalidatePrefix('account:rooms');
-    _domains.cache.invalidatePrefix('account:favorite-rooms');
     return room;
   }
 
@@ -3363,10 +3207,6 @@ class SyncTvService {
     );
   }
 
-  static Future<List<SyncTvUser>> adminListAdmins({String search = ''}) {
-    return _domains.admin.listAdmins(search: search);
-  }
-
   static Future<void> adminAddAdmin(String userId) {
     return _domains.admin.addAdmin(userId);
   }
@@ -3503,28 +3343,6 @@ class SyncTvService {
     );
   }
 
-  static Future<List<AdminProviderInstance>> adminListProviderInstances({
-    String providerType = '',
-    String search = '',
-    bool? enabled,
-    bool? tls,
-    provider_common_enum.ProviderInstanceListSortBy sortBy =
-        provider_common_enum
-            .ProviderInstanceListSortBy
-            .PROVIDER_INSTANCE_LIST_SORT_BY_NAME,
-    provider_common_enum.SortDirection sortDirection =
-        provider_common_enum.SortDirection.SORT_DIRECTION_ASC,
-  }) {
-    return _domains.admin.listProviderInstances(
-      providerType: providerType,
-      search: search,
-      enabled: enabled,
-      tls: tls,
-      sortBy: sortBy,
-      sortDirection: sortDirection,
-    );
-  }
-
   static Future<List<String>> listAvailableProviderInstances({
     String providerType = '',
   }) {
@@ -3619,30 +3437,6 @@ class SyncTvService {
         admin_enum.SortDirection.SORT_DIRECTION_DESC,
   }) {
     return _domains.admin.listActiveStreamsPage(
-      page: page,
-      pageSize: pageSize,
-      roomId: roomId,
-      userId: userId,
-      nodeId: nodeId,
-      search: search,
-      sortBy: sortBy,
-      sortDirection: sortDirection,
-    );
-  }
-
-  static Future<List<AdminActiveStream>> adminListActiveStreams({
-    int page = 1,
-    int pageSize = 50,
-    String roomId = '',
-    String userId = '',
-    String nodeId = '',
-    String search = '',
-    admin_enum.ActiveStreamListSortBy sortBy =
-        admin_enum.ActiveStreamListSortBy.ACTIVE_STREAM_LIST_SORT_BY_STARTED_AT,
-    admin_enum.SortDirection sortDirection =
-        admin_enum.SortDirection.SORT_DIRECTION_DESC,
-  }) {
-    return _domains.admin.listActiveStreams(
       page: page,
       pageSize: pageSize,
       roomId: roomId,

--- a/lib/features/media_p2p/infrastructure/p2p_length_metadata.dart
+++ b/lib/features/media_p2p/infrastructure/p2p_length_metadata.dart
@@ -3,19 +3,21 @@ import 'dart:typed_data';
 const _uint32Base = 0x100000000;
 
 int? decodeP2pResourceLength(Uint8List? metadata) {
-  if (metadata == null || metadata.length < 8) return null;
+  if (metadata == null || metadata.length != 9) return null;
   final data = ByteData.sublistView(metadata);
   final high = data.getUint32(0);
   final low = data.getUint32(4);
   return high * _uint32Base + low;
 }
 
-bool? decodeP2pRangeCapability(Uint8List metadata) =>
-    switch (metadata.length > 8 ? metadata[8] : 0) {
-      1 => true,
-      2 => false,
-      _ => null,
-    };
+bool? decodeP2pRangeCapability(Uint8List metadata) {
+  if (metadata.length != 9) return null;
+  return switch (metadata[8]) {
+    1 => true,
+    2 => false,
+    _ => null,
+  };
+}
 
 Uint8List encodeP2pResourceLength(int length, {bool? acceptsRanges}) {
   if (length < 0) throw ArgumentError.value(length, 'length');

--- a/lib/features/media_p2p/infrastructure/p2p_media_cache.dart
+++ b/lib/features/media_p2p/infrastructure/p2p_media_cache.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
+import 'package:synctv_app/core/async/async_operation_coordinator.dart';
 
 typedef P2pMediaCacheClock = DateTime Function();
 
@@ -40,7 +41,8 @@ class P2pMediaPersistentCache {
   final Duration cleanupInterval;
   final P2pMediaCacheClock _clock;
   final Map<String, _PersistentCacheEntry> _entries = {};
-  Future<void> _operationTail = Future.value();
+  final SerialAsyncOperationCoordinator _operations =
+      SerialAsyncOperationCoordinator();
   Future<void>? _initializing;
   Timer? _cleanupTimer;
   bool _closed = false;
@@ -156,15 +158,7 @@ class P2pMediaPersistentCache {
     if (_closed && !allowClosed) {
       return Future.error(StateError('P2P media cache is closed'));
     }
-    final result = Completer<T>();
-    _operationTail = _operationTail.then((_) async {
-      try {
-        result.complete(await operation());
-      } catch (error, stackTrace) {
-        result.completeError(error, stackTrace);
-      }
-    });
-    return result.future;
+    return _operations.run(operation);
   }
 
   Future<void> _initializeUnlocked() async {
@@ -219,6 +213,7 @@ class P2pMediaPersistentCache {
     for (final entry in _entries.values.toList(growable: false)) {
       if (_isExpired(entry, now)) await _removeEntry(entry);
     }
+    if (totalBytes <= maxBytes) return;
     final oldest = _entries.values.toList(growable: false)
       ..sort((left, right) => left.lastAccessed.compareTo(right.lastAccessed));
     for (final entry in oldest) {

--- a/lib/features/media_p2p/infrastructure/p2p_media_engine_io.dart
+++ b/lib/features/media_p2p/infrastructure/p2p_media_engine_io.dart
@@ -1573,7 +1573,7 @@ class P2pMediaEngine implements P2pMediaPlaybackEngine {
       '$lengthKey:length',
       recordStats: false,
     );
-    if (metadata != null && metadata.length >= 8) {
+    if (metadata != null) {
       final length = decodeP2pResourceLength(metadata);
       if (length != null && length > 0) {
         resource.originAcceptsRanges = decodeP2pRangeCapability(metadata);
@@ -1631,7 +1631,7 @@ class P2pMediaEngine implements P2pMediaPlaybackEngine {
           cancellation,
         );
         final bytes = peer?.bytes;
-        if (bytes != null && bytes.length >= 8) {
+        if (bytes != null) {
           final length = decodeP2pResourceLength(bytes);
           if (length != null && length > 0 && length <= maxP2pResourceLength) {
             resource.originAcceptsRanges = decodeP2pRangeCapability(bytes);
@@ -1660,25 +1660,15 @@ class P2pMediaEngine implements P2pMediaPlaybackEngine {
     final lengthKey = _cacheKey(resource.swarmId, resource.logicalKey);
     _progressiveLengths[lengthKey] = _CachedLength(length, now);
     final metadataKey = '$lengthKey:length';
-    final rangeCapability = switch (resource.originAcceptsRanges) {
-      true => 1,
-      false => 2,
-      null => 0,
-    };
     final cached = await _readCachedPiece(metadataKey, recordStats: false);
     if (cached != null &&
-        cached.length >= 9 &&
         decodeP2pResourceLength(cached) == length &&
-        cached[8] == rangeCapability) {
+        decodeP2pRangeCapability(cached) == resource.originAcceptsRanges) {
       return;
     }
     final metadata = encodeP2pResourceLength(
       length,
-      acceptsRanges: switch (rangeCapability) {
-        1 => true,
-        2 => false,
-        _ => null,
-      },
+      acceptsRanges: resource.originAcceptsRanges,
     );
     _memoryCache.put(metadataKey, metadata);
     _memoryCache.evictTo(_memoryCacheLimit);

--- a/lib/features/room/application/playback_overlay_preferences_controller.dart
+++ b/lib/features/room/application/playback_overlay_preferences_controller.dart
@@ -74,10 +74,7 @@ final class DanmakuOverlayStyle {
     'hideScroll': hideScroll,
   };
 
-  factory DanmakuOverlayStyle.fromJson(
-    Map<String, Object?> json, {
-    DanmakuOverlayStyle fallback = const DanmakuOverlayStyle(),
-  }) {
+  factory DanmakuOverlayStyle.fromJson(Map<String, Object?> json) {
     double number(String key, double defaultValue) {
       final value = json[key];
       return value is num ? value.toDouble() : defaultValue;
@@ -86,15 +83,15 @@ final class DanmakuOverlayStyle {
     bool flag(String key, bool defaultValue) =>
         json[key] is bool ? json[key] as bool : defaultValue;
     return DanmakuOverlayStyle(
-      fontSize: number('fontSize', fallback.fontSize),
-      opacity: number('opacity', fallback.opacity),
-      duration: number('duration', fallback.duration),
-      area: number('area', fallback.area),
-      strokeWidth: number('strokeWidth', fallback.strokeWidth),
-      massiveMode: flag('massiveMode', fallback.massiveMode),
-      hideTop: flag('hideTop', fallback.hideTop),
-      hideBottom: flag('hideBottom', fallback.hideBottom),
-      hideScroll: flag('hideScroll', fallback.hideScroll),
+      fontSize: number('fontSize', 25),
+      opacity: number('opacity', 0.8),
+      duration: number('duration', 8),
+      area: number('area', 1),
+      strokeWidth: number('strokeWidth', 1.5),
+      massiveMode: flag('massiveMode', false),
+      hideTop: flag('hideTop', false),
+      hideBottom: flag('hideBottom', false),
+      hideScroll: flag('hideScroll', false),
     ).normalized();
   }
 }
@@ -203,17 +200,6 @@ final class PlaybackOverlayPreferenceValues {
 
     bool flag(String key, bool fallback) =>
         json[key] is bool ? json[key] as bool : fallback;
-    final legacyStyle = DanmakuOverlayStyle(
-      fontSize: number('danmakuFontSize', 25),
-      opacity: number('danmakuOpacity', 0.8),
-      duration: number('danmakuDuration', 8),
-      area: number('danmakuArea', 1),
-      strokeWidth: number('danmakuStrokeWidth', 1.5),
-      massiveMode: flag('danmakuMassiveMode', false),
-      hideTop: flag('danmakuHideTop', false),
-      hideBottom: flag('danmakuHideBottom', false),
-      hideScroll: flag('danmakuHideScroll', false),
-    );
     Map<String, Object?> objectMap(Object? value) => value is Map
         ? Map<String, Object?>.from(value)
         : const <String, Object?>{};
@@ -233,11 +219,9 @@ final class PlaybackOverlayPreferenceValues {
       chatDanmakuEnabled: flag('chatDanmakuEnabled', true),
       videoDanmakuStyle: DanmakuOverlayStyle.fromJson(
         objectMap(json['videoDanmakuStyle']),
-        fallback: legacyStyle,
       ),
       chatDanmakuStyle: DanmakuOverlayStyle.fromJson(
         objectMap(json['chatDanmakuStyle']),
-        fallback: legacyStyle,
       ),
     ).normalized();
   }

--- a/lib/features/room/data/room_realtime_codec.dart
+++ b/lib/features/room/data/room_realtime_codec.dart
@@ -782,43 +782,10 @@ class RoomRealtimeCodec {
       chatDisplayColor: chat.displayColor,
       resourceObserveId: observeId,
       resourceVersion: version,
-      reactions: chat.reactions
-          .map(
-            (reaction) => ChatReactionSummaryInfo(
-              key: reaction.key,
-              count: reaction.count.toInt(),
-              reactedByMe: reaction.reactedByMe,
-            ),
-          )
-          .toList(),
+      reactions: chat.reactions.map(ChatReactionSummaryInfo.fromProto).toList(),
       reactionCount: chat.reactionCount,
-      mentions: chat.mentions
-          .map(
-            (mention) => ChatMentionInfo(
-              userId: mention.userId,
-              username: mention.username,
-              start: mention.start,
-              length: mention.length,
-            ),
-          )
-          .toList(),
-      images: chat.attachments
-          .map(
-            (attachment) => StoredImageInfo(
-              id: attachment.id,
-              storageBackend: '',
-              objectKey: '',
-              url: attachment.url,
-              mimeType: attachment.mimeType,
-              sizeBytes: attachment.sizeBytes.toInt(),
-              width: attachment.width,
-              height: attachment.height,
-              metadata: utf8.encode(
-                jsonEncode(fileMetadataToJson(attachment.metadata)),
-              ),
-            ),
-          )
-          .toList(),
+      mentions: chat.mentions.map(ChatMentionInfo.fromProto).toList(),
+      images: chat.attachments.map(StoredImageInfo.fromChatAttachment).toList(),
     );
   }
 
@@ -1031,81 +998,13 @@ class RoomRealtimeCodec {
         eventId: event.eventId,
         roomId: event.roomId,
         kind: event.kind,
-        message: _chatMessageInfoFromProto(event.message),
-        pin: event.hasPin() ? _chatPinFromProto(event.pin) : null,
+        message: RoomChatMessageInfo.fromProto(event.message),
+        pin: event.hasPin() ? ChatPinInfo.fromProto(event.pin) : null,
         occurredAt: event.occurredAt.toInt(),
         sequence: event.sequence.toInt(),
       ),
       resourceObserveId: observeId,
       resourceVersion: version.isEmpty ? event.sequence.toString() : version,
-    );
-  }
-
-  static RoomChatMessageInfo _chatMessageInfoFromProto(
-    client.ChatMessageReceive message,
-  ) {
-    return RoomChatMessageInfo(
-      id: message.id,
-      roomId: message.roomId,
-      userId: message.userId,
-      username: message.hasUsername() ? message.username : null,
-      content: message.content,
-      timestamp: message.timestamp.toInt(),
-      messageType: message.messageType,
-      displayPosition: message.displayPosition,
-      displayColor: message.displayColor,
-      version: message.version.toInt(),
-      editedAt: message.editedAt.toInt(),
-      deletedAt: message.deletedAt.toInt(),
-      status: message.status,
-      replyToMessageId: message.replyToMessageId,
-      images: message.attachments
-          .map(
-            (attachment) => StoredImageInfo(
-              id: attachment.id,
-              storageBackend: '',
-              objectKey: '',
-              url: attachment.url,
-              mimeType: attachment.mimeType,
-              sizeBytes: attachment.sizeBytes.toInt(),
-              width: attachment.width,
-              height: attachment.height,
-              metadata: utf8.encode(
-                jsonEncode(fileMetadataToJson(attachment.metadata)),
-              ),
-            ),
-          )
-          .toList(),
-      reactions: message.reactions
-          .map(
-            (reaction) => ChatReactionSummaryInfo(
-              key: reaction.key,
-              count: reaction.count.toInt(),
-              reactedByMe: reaction.reactedByMe,
-            ),
-          )
-          .toList(),
-      reactionCount: message.reactionCount,
-      mentions: message.mentions
-          .map(
-            (mention) => ChatMentionInfo(
-              userId: mention.userId,
-              username: mention.username,
-              start: mention.start,
-              length: mention.length,
-            ),
-          )
-          .toList(),
-      pin: message.hasPin() ? _chatPinFromProto(message.pin) : null,
-    );
-  }
-
-  static ChatPinInfo _chatPinFromProto(client.ChatMessagePin pin) {
-    return ChatPinInfo(
-      pinnedByUserId: pin.pinnedByUserId,
-      pinnedByUsername: pin.pinnedByUsername,
-      note: pin.note,
-      pinnedAt: pin.pinnedAt.toInt(),
     );
   }
 

--- a/lib/features/room/presentation/models/room_ui_capabilities.dart
+++ b/lib/features/room/presentation/models/room_ui_capabilities.dart
@@ -6,7 +6,6 @@ final class RoomUiCapabilities {
     required SyncTvRoom room,
     required SyncTvUser? currentUser,
     required AdminRoomMember? selfMember,
-    bool allowDiscoveryFallback = true,
   }) : _permissions = selfMember?.permissions ?? room.myPermissions,
        isRoomCreator =
            currentUser?.id.isNotEmpty == true &&

--- a/lib/features/room/presentation/room_screen.dart
+++ b/lib/features/room/presentation/room_screen.dart
@@ -382,7 +382,6 @@ class _RoomScreenState extends State<RoomScreen>
   List<SyncTvUser> _mentionCandidates = [];
   List<ChatMentionInfo> _pendingChatMentions = [];
   AdminRoomMember? _selfMember;
-  bool _membershipObservationStarted = false;
   SyncTvRoomSettings _roomSettings = SyncTvRoomSettings();
   bool _playModeUpdateInFlight = false;
   int _onlineMemberCount = 0;
@@ -491,7 +490,6 @@ class _RoomScreenState extends State<RoomScreen>
     room: widget.room,
     currentUser: _currentUser,
     selfMember: _selfMember,
-    allowDiscoveryFallback: !_membershipObservationStarted,
   );
 
   bool get _canManageRoom => _capabilities.canManageRoomSettings;
@@ -1398,7 +1396,6 @@ class _RoomScreenState extends State<RoomScreen>
   }
 
   void _invalidateRealtimeMembership() {
-    _membershipObservationStarted = true;
     if (_selfMember == null) return;
     if (mounted) {
       setState(() => _selfMember = null);

--- a/lib/features/voice/infrastructure/voice_chat_manager.dart
+++ b/lib/features/voice/infrastructure/voice_chat_manager.dart
@@ -31,7 +31,6 @@ class VoiceChatManager implements VoiceChatSession {
   final WebRtcNegotiationState<String, RTCIceCandidate> _negotiation =
       WebRtcNegotiationState();
   MediaStream? _localStream;
-  final Map<String, MediaStream> _remoteStreams = {};
   final Set<String> _connectedPeers = {};
   final VoiceSignalingCallback onSignalingMessage;
   final VoidCallback onStateChange;
@@ -266,14 +265,7 @@ class VoiceChatManager implements VoiceChatSession {
     }
   }
 
-  Future<void> handleLeave(String fromId) async {
-    await _closePeer(fromId);
-
-    // Cleanup remote stream
-    final stream = _remoteStreams.remove(fromId);
-    stream?.getTracks().forEach((track) => track.stop());
-    await stream?.dispose();
-  }
+  Future<void> handleLeave(String fromId) => _closePeer(fromId);
 
   Future<RTCPeerConnection> _replacePeerConnection(String remoteId) async {
     final pending = _negotiation.takeCandidates(remoteId);
@@ -315,12 +307,6 @@ class VoiceChatManager implements VoiceChatSession {
     _localStream?.getTracks().forEach((track) => track.stop());
     await _localStream?.dispose();
     _localStream = null;
-
-    for (var stream in _remoteStreams.values) {
-      stream.getTracks().forEach((track) => track.stop());
-      await stream.dispose();
-    }
-    _remoteStreams.clear();
 
     for (var pc in _peerConnections.values) {
       await pc.close();

--- a/packages/synctv_video_player_media_kit/lib/src/cancellable_media_kit_video_player.dart
+++ b/packages/synctv_video_player_media_kit/lib/src/cancellable_media_kit_video_player.dart
@@ -117,11 +117,7 @@ class CancellableMediaKitVideoPlayer extends VideoPlayerPlatform {
   static Stream<AdaptiveVideoTrackSnapshot> adaptiveVideoTracksFor(
     int playerId,
   ) {
-    final platform = VideoPlayerPlatform.instance;
-    if (platform is! CancellableMediaKitVideoPlayer) {
-      return const Stream<AdaptiveVideoTrackSnapshot>.empty();
-    }
-    final runtime = platform._sessions[playerId]?.runtime;
+    final runtime = _runtimeFor(playerId);
     if (runtime is! AdaptiveVideoTrackRuntime) {
       return const Stream<AdaptiveVideoTrackSnapshot>.empty();
     }
@@ -132,9 +128,7 @@ class CancellableMediaKitVideoPlayer extends VideoPlayerPlatform {
     int playerId,
     String trackId,
   ) async {
-    final platform = VideoPlayerPlatform.instance;
-    if (platform is! CancellableMediaKitVideoPlayer) return;
-    final runtime = platform._sessions[playerId]?.runtime;
+    final runtime = _runtimeFor(playerId);
     if (runtime is AdaptiveVideoTrackRuntime) {
       await (runtime as AdaptiveVideoTrackRuntime).selectAdaptiveVideoTrack(
         trackId,

--- a/test/data/synctv_api/protobuf_synctv_test.dart
+++ b/test/data/synctv_api/protobuf_synctv_test.dart
@@ -4330,7 +4330,7 @@ void main() {
         'http://${server.address.host}:${server.port}',
       );
 
-      final playback = await SyncTvService.switchMediaAndPlay(
+      final playback = await SyncTvService.switchMedia(
         'room_1',
         'med_1',
       );
@@ -4730,22 +4730,13 @@ void main() {
     );
   });
 
-  test('playback mapping recognizes legacy live danmaku delivery', () {
-    final legacySources = <(String, String)>[
-      ('synctv-bilibili-live', 'https://example.test/bilibili'),
-      ('synctv-twitch-live', 'https://example.test/twitch'),
-      ('synctv-huya-live', 'https://example.test/huya'),
-      ('synctv-douyu-live', 'https://example.test/douyu'),
-      ('synctv-douyin-live', 'https://example.test/douyin'),
-      ('synctv-acfun-live', 'https://example.test/acfun'),
-      ('legacy', 'https://example.test/live-danmaku/stream'),
-    ];
-
-    for (final (format, url) in legacySources) {
+  test('playback mapping uses the explicit danmaku delivery contract', () {
+    const url = 'https://example.test/live-danmaku/stream';
+    for (final delivery in client.PlaybackDanmakuDelivery.values) {
       final entry = RoomMediaEntry.fromPlaybackProto(
         client.Playback(
-          mediaId: 'med_legacy',
-          name: 'Legacy live danmaku',
+          mediaId: 'med_danmaku',
+          name: 'Danmaku delivery',
           playbackInfos: [
             MapEntry(
               'live',
@@ -4759,9 +4750,10 @@ void main() {
                 ],
                 danmakus: [
                   client.PlaybackDanmaku(
-                    name: 'Legacy',
+                    name: 'Danmaku',
                     url: url,
-                    format: format,
+                    format: 'synctv-bilibili-live',
+                    delivery: delivery,
                   ),
                 ],
               ),
@@ -4771,8 +4763,22 @@ void main() {
         ),
       );
 
-      expect(entry.streamDanmu, url, reason: format);
-      expect(entry.danmu, isNull, reason: format);
+      expect(
+        entry.streamDanmu,
+        delivery ==
+                client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_EVENT_STREAM
+            ? url
+            : null,
+        reason: delivery.name,
+      );
+      expect(
+        entry.danmu,
+        delivery ==
+                client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_DOCUMENT
+            ? url
+            : null,
+        reason: delivery.name,
+      );
     }
   });
 
@@ -6368,17 +6374,18 @@ void main() {
     expect(requests.last.url.path, '/api/rooms/room_1/streams/med_1');
   });
 
-  test('legacy publish key responses default to single-use', () async {
+  test('publish key info preserves the server key type', () async {
     final api = SyncTvApiClient(
       baseUrl: 'https://example.test/api',
       session: SyncTvSession()..updateAccountTokens(accessToken: 'token'),
       httpClient: MockClient((request) async {
         return http.Response(
           jsonEncode({
-            'publishKey': 'pub_legacy',
+            'publishKey': 'pub_1',
             'rtmpUrl': 'rtmp://example.test/live',
-            'streamKey': 'stream_legacy',
+            'streamKey': 'stream_1',
             'expiresAt': '1760000100',
+            'type': client_enum.PublishKeyType.PUBLISH_KEY_TYPE_EXPIRING.value,
           }),
           200,
           headers: {'content-type': 'application/json'},
@@ -6395,7 +6402,7 @@ void main() {
 
     expect(
       publish.keyType,
-      client_enum.PublishKeyType.PUBLISH_KEY_TYPE_SINGLE_USE,
+      client_enum.PublishKeyType.PUBLISH_KEY_TYPE_EXPIRING,
     );
     expect(publish.expiresAt, 1760000100);
   });

--- a/test/data/synctv_api/protobuf_synctv_test.dart
+++ b/test/data/synctv_api/protobuf_synctv_test.dart
@@ -4330,10 +4330,7 @@ void main() {
         'http://${server.address.host}:${server.port}',
       );
 
-      final playback = await SyncTvService.switchMedia(
-        'room_1',
-        'med_1',
-      );
+      final playback = await SyncTvService.switchMedia('room_1', 'med_1');
 
       expect(playback.isPlaying, isTrue);
       expect(playback.playingMediaId, 'med_1');
@@ -4766,7 +4763,9 @@ void main() {
       expect(
         entry.streamDanmu,
         delivery ==
-                client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_EVENT_STREAM
+                client
+                    .PlaybackDanmakuDelivery
+                    .PLAYBACK_DANMAKU_DELIVERY_EVENT_STREAM
             ? url
             : null,
         reason: delivery.name,
@@ -4774,7 +4773,9 @@ void main() {
       expect(
         entry.danmu,
         delivery ==
-                client.PlaybackDanmakuDelivery.PLAYBACK_DANMAKU_DELIVERY_DOCUMENT
+                client
+                    .PlaybackDanmakuDelivery
+                    .PLAYBACK_DANMAKU_DELIVERY_DOCUMENT
             ? url
             : null,
         reason: delivery.name,

--- a/test/features/media_p2p/infrastructure/p2p_length_metadata_test.dart
+++ b/test/features/media_p2p/infrastructure/p2p_length_metadata_test.dart
@@ -19,15 +19,20 @@ void main() {
     }
   });
 
-  test('length metadata preserves range capability and legacy records', () {
+  test('length metadata preserves range capability', () {
     final unsupported = encodeP2pResourceLength(42, acceptsRanges: false);
     expect(decodeP2pRangeCapability(unsupported), isFalse);
 
     final unknown = encodeP2pResourceLength(42);
     expect(decodeP2pRangeCapability(unknown), isNull);
+  });
 
-    final legacy = Uint8List.sublistView(unknown, 0, 8);
-    expect(decodeP2pResourceLength(legacy), 42);
-    expect(decodeP2pRangeCapability(legacy), isNull);
+  test('length metadata rejects incomplete and oversized records', () {
+    expect(decodeP2pResourceLength(null), isNull);
+    for (final size in [0, 7, 8, 10]) {
+      final metadata = Uint8List(size);
+      expect(decodeP2pResourceLength(metadata), isNull);
+      expect(decodeP2pRangeCapability(metadata), isNull);
+    }
   });
 }

--- a/test/features/media_p2p/infrastructure/p2p_media_engine_test.dart
+++ b/test/features/media_p2p/infrastructure/p2p_media_engine_test.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:synctv_app/features/media_p2p/infrastructure/p2p_length_metadata.dart';
 import 'package:synctv_app/features/media_p2p/infrastructure/p2p_media_cache.dart';
 import 'package:synctv_app/features/media_p2p/infrastructure/p2p_media_engine.dart';
 import 'package:synctv_app/features/media_p2p/application/p2p_media_runtime.dart';
@@ -2543,8 +2544,7 @@ segment.ts?token=secret
     origin.listen((request) async {
       // Keep the origin header phase pending; the peer owns both metadata and data.
     });
-    final lengthBytes = Uint8List(8);
-    ByteData.sublistView(lengthBytes).setUint64(0, 4);
+    final lengthBytes = encodeP2pResourceLength(4);
     final requestedPieces = <String>[];
     final engine = P2pMediaEngine(
       originHeaderPeerRetryDelay: const Duration(milliseconds: 20),
@@ -2644,8 +2644,7 @@ segment.ts?token=secret
       );
 
       final body = Uint8List.fromList([4, 3, 2, 1]);
-      final lengthBytes = Uint8List(8);
-      ByteData.sublistView(lengthBytes).setUint64(0, body.length);
+      final lengthBytes = encodeP2pResourceLength(body.length);
       var lengthRequests = 0;
       final engine = P2pMediaEngine(
         originHeaderPeerRetryDelay: const Duration(milliseconds: 10),
@@ -2677,7 +2676,7 @@ segment.ts?token=secret
       expect(head.acceptRanges, 'bytes');
       expect(await _getBytes(local), body);
       expect(lengthRequests, 2);
-      expect(engine.stats.value.p2pBytes, body.length + 8);
+      expect(engine.stats.value.p2pBytes, body.length + lengthBytes.length);
     },
   );
 

--- a/test/features/room/application/playback_overlay_preferences_controller_test.dart
+++ b/test/features/room/application/playback_overlay_preferences_controller_test.dart
@@ -86,19 +86,6 @@ void main() {
     expect(restored.chatDanmakuStyle.opacity, 0.9);
   });
 
-  test('legacy danmaku style initializes both independent styles', () {
-    final restored = PlaybackOverlayPreferenceValues.fromJson({
-      'danmakuFontSize': 31,
-      'danmakuOpacity': 0.6,
-      'danmakuHideTop': true,
-    });
-
-    expect(restored.videoDanmakuStyle.fontSize, 31);
-    expect(restored.chatDanmakuStyle.fontSize, 31);
-    expect(restored.videoDanmakuStyle.opacity, 0.6);
-    expect(restored.chatDanmakuStyle.hideTop, isTrue);
-  });
-
   test(
     'video content rectangle stays within viewport at every aspect ratio',
     () {

--- a/test/features/room/presentation/models/room_ui_capabilities_test.dart
+++ b/test/features/room/presentation/models/room_ui_capabilities_test.dart
@@ -71,7 +71,6 @@ void main() {
           room: _room(myPermissions: RoomAdminPermissions.all),
           currentUser: _user(),
           selfMember: null,
-          allowDiscoveryFallback: false,
         );
 
         expect(capabilities.canBrowseLibrary, isTrue);

--- a/tool/local_backend_deep_business_test.dart
+++ b/tool/local_backend_deep_business_test.dart
@@ -162,7 +162,7 @@ Future<void> _exerciseWatchers(String roomId, int stamp) async {
   print('watchers_pin_chat');
   await SyncTvService.pinChatMessage(roomId, msg.id, note: 'watch pin');
   print('watchers_switch_playback');
-  await SyncTvService.switchMediaAndPlay(roomId, mediaId);
+  await SyncTvService.switchMedia(roomId, mediaId);
 
   print('watchers_update_settings');
   final settings = await SyncTvService.getRoomSettings(roomId, refresh: true);
@@ -287,7 +287,7 @@ Future<void> _exerciseMediaAndRealtime(
     playbackKind: source_enum.PlaybackKind.PLAYBACK_KIND_REGULAR,
     name: 'playback direct $stamp',
   );
-  await SyncTvService.switchMediaAndPlay(roomId, directId);
+  await SyncTvService.switchMedia(roomId, directId);
   await SyncTvService.updatePlaybackState(
     roomId,
     action: PlaybackControlAction.seek,
@@ -386,7 +386,7 @@ Future<void> _exercisePlaybackHistory(
       name: 'history $index $stamp',
     );
     mediaIds.add(mediaId);
-    await SyncTvService.switchMediaAndPlay(roomId, mediaId);
+    await SyncTvService.switchMedia(roomId, mediaId);
   }
 
   final newestPage = await SyncTvService.listPlaybackHistory(roomId, limit: 2);
@@ -654,7 +654,9 @@ Future<void> _exerciseAdminLifecycle({
     () => SyncTvService.adminReconnectProviderInstance(providerName),
     'provider_reconnect_missing',
   );
-  final listed = await SyncTvService.adminListProviderInstances();
+  final listed = await SyncTvService.adminListProviderInstancesPage(
+    pageSize: 100,
+  );
   final availableAlist = await SyncTvService.listAvailableProviderInstances(
     providerType: 'alist',
   );
@@ -663,7 +665,7 @@ Future<void> _exerciseAdminLifecycle({
     throw StateError('provider discovery incomplete');
   }
   print(
-    'provider_instances=${listed.length} alist_available=$availableAlist alist_backends=$alistBackends',
+    'provider_instances=${listed.instances.length} alist_available=$availableAlist alist_backends=$alistBackends',
   );
 
   final settings = await SyncTvService.runtimeGetSettings(refresh: true);
@@ -691,8 +693,8 @@ Future<void> _exerciseAdminLifecycle({
     );
   }
 
-  final streams = await SyncTvService.adminListActiveStreams(roomId: roomId);
-  print('active_streams=${streams.length}');
+  final streams = await SyncTvService.adminListActiveStreamsPage(roomId: roomId);
+  print('active_streams=${streams.streams.length}');
   final stats = await SyncTvService.adminGetServiceState();
   if (stats.totalUsers < 1 || stats.totalRooms < 1) {
     throw StateError('admin stats incomplete');

--- a/tool/local_backend_deep_business_test.dart
+++ b/tool/local_backend_deep_business_test.dart
@@ -693,7 +693,9 @@ Future<void> _exerciseAdminLifecycle({
     );
   }
 
-  final streams = await SyncTvService.adminListActiveStreamsPage(roomId: roomId);
+  final streams = await SyncTvService.adminListActiveStreamsPage(
+    roomId: roomId,
+  );
   print('active_streams=${streams.streams.length}');
   final stats = await SyncTvService.adminGetServiceState();
   if (stats.totalUsers < 1 || stats.totalRooms < 1) {

--- a/tool/local_backend_smoke.dart
+++ b/tool/local_backend_smoke.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:synctv_app/contracts/account_models.dart';
 import 'package:synctv_app/contracts/public_models.dart';
+import 'package:synctv_app/core/time/synced_clock.dart';
 import 'package:synctv_app/features/room/data/room_realtime_codec.dart';
 import 'package:synctv_app/features/room/data/room_realtime_connection.dart';
 import 'package:synctv_app/features/room/domain/room_realtime.dart';
@@ -90,7 +91,7 @@ Future<void> runSmoke(String baseUrl) async {
   );
   print('media=$mediaId page_total=${mediaPage.total}');
 
-  await SyncTvService.switchMediaAndPlay(room.roomId, mediaId);
+  await SyncTvService.switchMedia(room.roomId, mediaId);
   await SyncTvService.updatePlaybackState(
     room.roomId,
     action: PlaybackControlAction.pause,
@@ -229,7 +230,7 @@ class _RealtimeSmokeProbe {
       createWebSocketUri: SyncTvService.createRoomWebSocketUri,
       encodeMessage: SyncTvService.encodeRealtimeMessageJson,
       decodeMessage: SyncTvService.decodeRealtimeMessageJson,
-      nowMillis: SyncTvService.serverNowMillis,
+      nowMillis: SyncedClock.nowMillis,
       initialMessages: [
         ...RoomRealtimeCodec.encodeInitialObservations(),
         RoomRealtimeCodec.encodePlaylistObservation(),

--- a/tool/local_backend_ui_seed.dart
+++ b/tool/local_backend_ui_seed.dart
@@ -417,7 +417,7 @@ Future<void> _createPrimaryRoomMedia(
     mediaId,
     await _imageUpload(coverPath),
   );
-  await SyncTvService.switchMediaAndPlay(
+  await SyncTvService.switchMedia(
     roomId,
     mediaId,
     playlistId: playlist.id,

--- a/tool/local_backend_ui_seed.dart
+++ b/tool/local_backend_ui_seed.dart
@@ -417,11 +417,7 @@ Future<void> _createPrimaryRoomMedia(
     mediaId,
     await _imageUpload(coverPath),
   );
-  await SyncTvService.switchMedia(
-    roomId,
-    mediaId,
-    playlistId: playlist.id,
-  );
+  await SyncTvService.switchMedia(roomId, mediaId, playlistId: playlist.id);
 }
 
 Future<void> _seedChat(String roomId) async {

--- a/tool/local_p2p_ui_seed.dart
+++ b/tool/local_p2p_ui_seed.dart
@@ -40,7 +40,7 @@ void main() {
     }
     const switchMediaId = String.fromEnvironment('SYNCTV_P2P_SWITCH_MEDIA_ID');
     if (switchMediaId.isNotEmpty) {
-      await SyncTvService.switchMediaAndPlay(roomId, switchMediaId);
+      await SyncTvService.switchMedia(roomId, switchMediaId);
       if (const bool.fromEnvironment('SYNCTV_P2P_PAUSE_AFTER_SWITCH')) {
         await SyncTvService.updatePlaybackState(
           roomId,
@@ -149,7 +149,7 @@ void main() {
       ),
     );
 
-    await SyncTvService.switchMediaAndPlay(roomId, vodId);
+    await SyncTvService.switchMedia(roomId, vodId);
     print('P2P_SEED_PLAYLIST_ID=${playlist.id}');
     print('P2P_SEED_VOD_ID=$vodId');
     print('P2P_SEED_LIVE_ID=$liveId');


### PR DESCRIPTION
Removes unused API entry points, redundant wrappers, and obsolete compatibility paths. Tools and integration tests now call the existing `switchMedia` and paginated admin APIs directly; unused domain/transport methods, cache invalidations, and the ignored room permission option and its state are deleted.

Playback preferences now read only the independent video/chat styles, danmaku selection follows the explicit delivery enum, and publish-key types are preserved from the server response. P2P length metadata requires the current 9-byte record, with duplicate range-capability conversions removed.

Compatibility removal is intentional: old shared danmaku settings use current defaults, danmaku without a declared delivery is skipped, and 8-byte P2P metadata is rejected.

Validation:
- `fvm flutter test --no-pub --reporter expanded`: 925 tests passed.
- `fvm flutter analyze --no-pub`: no issues.
- Architecture guard, generated gateway checks, and `git diff --check` passed.
- External backend and device integration tests were not run.
